### PR TITLE
Remove DynamoDB table resource from eventbridge-scheduler template

### DIFF
--- a/plugins/eventbridge-scheduler/cf-template.yaml
+++ b/plugins/eventbridge-scheduler/cf-template.yaml
@@ -1,7 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Parameters:
-  TableNamePrefix:
-    Type: String
   SchedulerGroupName:
     Type: String
   ProtocolType:
@@ -12,49 +10,8 @@ Parameters:
       - https
   EndpointUrl:
     Type: String
-  CategoryName:
-    Description: "Resource category name"
-    Type: String
-    Default: "eventbridge-scheduler"
-  DynamoDBDeletionPolicy:
-    Description: "Deletion policy for the DynamoDB table"
-    Type: String
-    Default: Retain
-    AllowedValues:
-      - Delete
-      - Retain
 
 Resources:
-  schedulerEvent:
-    Type: AWS::DynamoDB::Table
-    Properties:
-      TableName: !Join
-        - "-"
-        - - !Ref TableNamePrefix
-          - !Ref CategoryName
-          - "SchedulerEvent"
-      AttributeDefinitions:
-        - AttributeName: id
-          AttributeType: S
-        - AttributeName: eventType
-          AttributeType: S
-      KeySchema:
-        - AttributeName: id
-          KeyType: HASH
-      GlobalSecondaryIndexes:
-        - IndexName: eventType-index
-          KeySchema:
-            - AttributeName: eventType
-              KeyType: HASH
-          Projection:
-            ProjectionType: ALL
-      BillingMode: PAY_PER_REQUEST
-      PointInTimeRecoverySpecification:
-        PointInTimeRecoveryEnabled: true
-      SSESpecification:
-        SSEEnabled: true
-    DeletionPolicy: !Ref DynamoDBDeletionPolicy
-
   ScheduleGroup:
     Type: AWS::Scheduler::ScheduleGroup
     Properties:


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### 🎉 Reason for this change

<!--What is the bug or use case behind this change?-->

I removed the DynamoDB table from the CloudFormation Template due to the changes in https://github.com/sony/stamp/pull/4 , which discontinued its use.

### 🔀 Description of changes

<!--What code changes did you make? Have you made any important design decisions?-->

### 🖨️ Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### 👀 Points to be checked especially by reviewers (if any)

<!--Describe any particular points you would like reviewers to check.-->

### 🔗 Related links

<!--Please include any relevant links -->
