### PR TITLE
Add multi-workspace support to Slack plugin.

### DIFF
--- a/apps/web-ui/src/app/account/settings/page.tsx
+++ b/apps/web-ui/src/app/account/settings/page.tsx
@@ -21,6 +21,8 @@ export default async function Page({ params }: { params: { groupId: string } }) 
 }
 
 async function AccountLink() {
+  const notificationTypes = await stampHubClient.systemRequest.notification.listNotificationTypes.query();
+
   return (
     <Container size="3" px="8">
       <Card>
@@ -29,14 +31,16 @@ async function AccountLink() {
             <Heading as="h2">Account Link</Heading>
           </Grid>
           <Box>
-            <Flex direction="column" gap="1">
-              <Heading size="3">Slack</Heading>
-              <Container px="2">
-                <Text size="2">
-                  <Link href="/account-link/start/slack"> Start Account Link</Link>
-                </Text>
-              </Container>
-            </Flex>
+            {notificationTypes.map((notificationType) => (
+              <Flex direction="column" gap="1" p="2" key={notificationType.id}>
+                <Heading size="3">{notificationType.name}</Heading>
+                <Container px="2">
+                  <Text size="2">
+                    <Link href={`/account-link/start/${notificationType.id}`}> Start Account Link</Link>
+                  </Text>
+                </Container>
+              </Flex>
+            ))}
           </Box>
         </Flex>
       </Card>

--- a/apps/web-ui/src/components/group/approvalRequestNotificationDialog.tsx
+++ b/apps/web-ui/src/components/group/approvalRequestNotificationDialog.tsx
@@ -8,7 +8,7 @@ import { updateApprovalRequestNotificationSubmit } from "@/server-actions/group/
 import { Group } from "@/type";
 import { StampHubRouterOutput } from "@stamp-lib/stamp-hub";
 import { InfoCircledIcon } from "@radix-ui/react-icons";
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 
 async function listNotificationTypes() {
   const result = await fetch("/api/notification/list");
@@ -112,7 +112,10 @@ export function NotificationPropertyForm({
   group: Group;
   notificationTypes: StampHubRouterOutput["systemRequest"]["notification"]["listNotificationTypes"];
 }) {
-  const [selectedNotificationTypeId, setSelectedNotificationTypeId] = useState(notificationTypes[0].id);
+  const [selectedNotificationTypeId, setSelectedNotificationTypeId] = useState(
+    // if approvalRequestNotifications exists, use the first one, otherwise use the first notification type
+    group.approvalRequestNotifications?.[0]?.notificationChannel.typeId || notificationTypes[0].id
+  );
   const [selectedNotificationType, setSelectedNotificationType] = useState<
     StampHubRouterOutput["systemRequest"]["notification"]["listNotificationTypes"][0] | undefined
   >(notificationTypes.find((notificationType) => notificationType.id === selectedNotificationTypeId));
@@ -152,73 +155,75 @@ export function NotificationPropertyForm({
       </Flex>
       <input type="hidden" name="approvalRequestNotificationId" value={targetNotificationProperty?.id} />
 
-      {selectedNotificationType?.channelConfigProperties.map((channelConfigProperty) => {
-        const textFiledId = `channelConfigProperty.${channelConfigProperty.id}`;
-        const inputFieldComponent = (() => {
-          switch (channelConfigProperty.type) {
-            case "string":
-              return (
-                <TextField.Root
-                  name={textFiledId}
-                  id={textFiledId}
-                  // Use 'as' because the case statement is checking whether it is a string type property.
-                  defaultValue={targetNotificationProperty?.notificationChannel.properties[channelConfigProperty.id] as "string" | "undefined"}
-                />
-              );
-            case "number":
-              return (
-                <TextField.Root
-                  name={textFiledId}
-                  id={textFiledId}
-                  type="number"
-                  // Use 'as' because the case statement is checking whether it is a number type property.
-                  defaultValue={targetNotificationProperty?.notificationChannel.properties[channelConfigProperty.id] as "number" | "undefined"}
-                />
-              );
-            case "boolean":
-              return (
-                <RadioGroup.Root
-                  name={textFiledId}
-                  id={textFiledId}
-                  // Use 'as' because the case statement is checking whether it is a number type property.
-                  defaultValue={(targetNotificationProperty?.notificationChannel.properties[channelConfigProperty.id] as "boolean" | "undefined")?.toString()}
-                >
-                  <Flex gap="2" direction="column">
-                    <Text size="2">
-                      <Flex gap="2">
-                        <RadioGroup.Item value="true" /> true
-                      </Flex>
-                    </Text>
-                    <Text size="2">
-                      <Flex gap="2">
-                        <RadioGroup.Item value="false" /> false
-                      </Flex>
-                    </Text>
-                  </Flex>
-                </RadioGroup.Root>
-              );
-          }
-        })();
+      <Fragment key={selectedNotificationTypeId}>
+        {selectedNotificationType?.channelConfigProperties.map((channelConfigProperty) => {
+          const textFiledId = `channelConfigProperty.${channelConfigProperty.id}`;
+          const inputFieldComponent = (() => {
+            switch (channelConfigProperty.type) {
+              case "string":
+                return (
+                  <TextField.Root
+                    name={textFiledId}
+                    id={textFiledId}
+                    // Use 'as' because the case statement is checking whether it is a string type property.
+                    defaultValue={targetNotificationProperty?.notificationChannel.properties[channelConfigProperty.id] as "string" | "undefined"}
+                  />
+                );
+              case "number":
+                return (
+                  <TextField.Root
+                    name={textFiledId}
+                    id={textFiledId}
+                    type="number"
+                    // Use 'as' because the case statement is checking whether it is a number type property.
+                    defaultValue={targetNotificationProperty?.notificationChannel.properties[channelConfigProperty.id] as "number" | "undefined"}
+                  />
+                );
+              case "boolean":
+                return (
+                  <RadioGroup.Root
+                    name={textFiledId}
+                    id={textFiledId}
+                    // Use 'as' because the case statement is checking whether it is a number type property.
+                    defaultValue={(targetNotificationProperty?.notificationChannel.properties[channelConfigProperty.id] as "boolean" | "undefined")?.toString()}
+                  >
+                    <Flex gap="2" direction="column">
+                      <Text size="2">
+                        <Flex gap="2">
+                          <RadioGroup.Item value="true" /> true
+                        </Flex>
+                      </Text>
+                      <Text size="2">
+                        <Flex gap="2">
+                          <RadioGroup.Item value="false" /> false
+                        </Flex>
+                      </Text>
+                    </Flex>
+                  </RadioGroup.Root>
+                );
+            }
+          })();
 
-        return (
-          <Flex direction="column" gap="1" key={channelConfigProperty.id}>
-            <label htmlFor={textFiledId}>
-              <Text as="div" size="3" mb="1" weight="bold">
-                {channelConfigProperty.name}
-              </Text>
-            </label>
-            <Flex p="1" align="center" gap="1">
-              <Text size="2" color={currentAccentColor}>
-                <InfoCircledIcon />
-              </Text>
-              <Text size="2" color={currentAccentColor}>
-                {channelConfigProperty.description}
-              </Text>
+          return (
+            <Flex direction="column" gap="1" key={channelConfigProperty.id}>
+              <label htmlFor={textFiledId}>
+                <Text as="div" size="3" mb="1" weight="bold">
+                  {channelConfigProperty.name}
+                </Text>
+              </label>
+              <Flex p="1" align="center" gap="1">
+                <Text size="2" color={currentAccentColor}>
+                  <InfoCircledIcon />
+                </Text>
+                <Text size="2" color={currentAccentColor}>
+                  {channelConfigProperty.description}
+                </Text>
+              </Flex>
+              {inputFieldComponent}
             </Flex>
-            {inputFieldComponent}
-          </Flex>
-        );
-      })}
+          );
+        })}
+      </Fragment>
     </Flex>
   );
 }

--- a/apps/web-ui/src/type.ts
+++ b/apps/web-ui/src/type.ts
@@ -15,5 +15,4 @@ export type ResourceOutline = StampHubRouterOutput["userRequest"]["resource"]["l
 export type ResourceAuditItems = StampHubRouterOutput["userRequest"]["resource"]["listAuditItem"]["auditItems"][0];
 
 export type ApprovalFlow = StampHubRouterOutput["userRequest"]["approvalFlow"]["get"];
-
 export type ApprovalRequest = StampHubRouterOutput["userRequest"]["approvalRequest"]["listByApprovalFlowId"]["items"][0];

--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -10,7 +10,7 @@
 
 If you want to use multiple workspaces, you can create multiple instances of the Slack plugin.
 
-- Each instance should have a different `basePath`, `workSpaceId` and `workSpaceName` in the configuration.
+- Each instance should have a different `basePath`, `workspaceId` and `workspaceName` in the configuration.
 - `dynamoDBTableNamePrefix` should be the same for all instances.
 - You need create a Slack App for each workspace and set the `slackSigningSecret`, `slackBotToken`, `slackVerificationToken`, `slackClientId`, `slackClientSecret` for each workspace.
 
@@ -27,8 +27,8 @@ const slackPluginForWorkspaceA = await createSlackPlugin({
   region: "us-west-2",
   logLevel: "INFO",
   basePath: "/plugin/slack-workspace-a", // Set For each workspace
-  workSpaceId: "XXXXX", // Set For each workspace
-  workSpaceName: "Workspace A", // Set For each workspace
+  workspaceId: "XXXXX", // Set For each workspace
+  workspaceName: "Workspace A", // Set For each workspace
 });
 
 const slackPluginForWorkspaceB = await createSlackPlugin({
@@ -43,8 +43,8 @@ const slackPluginForWorkspaceB = await createSlackPlugin({
   region: "us-west-2",
   logLevel: "INFO",
   basePath: "/plugin/slack-workspace-b", // Set For each workspace
-  workSpaceId: "XXXXX", // Set For each workspace
-  workSpaceName: "Workspace B", // Set For each workspace
+  workspaceId: "XXXXX", // Set For each workspace
+  workspaceName: "Workspace B", // Set For each workspace
 });
 
 const config = await createConfigProvider({

--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -6,6 +6,67 @@
 2. Create a Slack App using the [manifest](./manifest.yml) and install it to your workspace: [Slack Manifest Documentation](https://api.slack.com/reference/manifests)
 3. Deploy [cf-template.yaml (slack)](./cf-template.yaml) to CloudFormation
 
+### How to use multiple workspaces
+
+If you want to use multiple workspaces, you can create multiple instances of the Slack plugin.
+
+- Each instance should have a different `basePath`, `workSpaceId` and `workSpaceName` in the configuration.
+- `dynamoDBTableNamePrefix` should be the same for all instances.
+- You need create a Slack App for each workspace and set the `slackSigningSecret`, `slackBotToken`, `slackVerificationToken`, `slackClientId`, `slackClientSecret` for each workspace.
+
+```ts
+const slackPluginForWorkspaceA = await createSlackPlugin({
+  slackSigningSecret: "XXXXX",
+  slackBotToken: "XXXXX",
+  slackVerificationToken: "XXXXX",
+  slackClientId: "XXXXX",
+  slackClientSecret: "XXXXX",
+  hostDomain: "example.com",
+  stampHubUrl: "http://localhost:4000",
+  dynamoDBTableNamePrefix: "XXXXX",
+  region: "us-west-2",
+  logLevel: "INFO",
+  basePath: "/plugin/slack-workspace-a", // Set For each workspace
+  workSpaceId: "XXXXX", // Set For each workspace
+  workSpaceName: "Workspace A", // Set For each workspace
+});
+
+const slackPluginForWorkspaceB = await createSlackPlugin({
+  slackSigningSecret: "XXXXX",
+  slackBotToken: "XXXXX",
+  slackVerificationToken: "XXXXX",
+  slackClientId: "XXXXX",
+  slackClientSecret: "XXXXX",
+  hostDomain: "example.com",
+  stampHubUrl: "http://localhost:4000",
+  dynamoDBTableNamePrefix: "XXXXX",
+  region: "us-west-2",
+  logLevel: "INFO",
+  basePath: "/plugin/slack-workspace-b", // Set For each workspace
+  workSpaceId: "XXXXX", // Set For each workspace
+  workSpaceName: "Workspace B", // Set For each workspace
+});
+
+const config = await createConfigProvider({
+  catalogs: [
+    // Add your catalog config here
+  ],
+  notificationPlugins: [slackPluginForWorkspaceA.notificationPluginConfig
+      , slackPluginForWorkspaceB.notificationPluginConfig],
+  ],
+});
+
+const pluginRouter = createPluginRouter({
+  basePath: "/plugin",
+  plugins: {
+    // For each workspace, the plugin ID should be the same as the last segment of the basePath
+    "slack-workspace-a": slackPluginForWorkspaceA.router,
+    "slack-workspace-b": slackPluginForWorkspaceB.router,
+    // Add other plugins here
+  },
+});
+```
+
 ### How to execute test
 
 1. Set environment variables

--- a/plugins/slack/src/config.ts
+++ b/plugins/slack/src/config.ts
@@ -12,6 +12,8 @@ export const SlackPluginConfig = z.object({
   dynamoDBTableNamePrefix: z.string(),
   dynamoDBTableCategoryName: z.string().default("slack"),
   region: z.string(),
+  workSpaceId: z.string().optional(), // for multi-workspace support. If you want to use the multiple workspaces, you need to set the workSpaceID
+  workSpaceName: z.string().optional(), // for multi-workspace support. If you want to use the multiple workspaces, you need to set the workSpaceName
 });
 export type SlackPluginConfigInput = z.input<typeof SlackPluginConfig>;
 export type SlackPluginConfig = z.output<typeof SlackPluginConfig>;

--- a/plugins/slack/src/config.ts
+++ b/plugins/slack/src/config.ts
@@ -12,8 +12,8 @@ export const SlackPluginConfig = z.object({
   dynamoDBTableNamePrefix: z.string(),
   dynamoDBTableCategoryName: z.string().default("slack"),
   region: z.string(),
-  workSpaceId: z.string().optional(), // for multi-workspace support. If you want to use the multiple workspaces, you need to set the workSpaceID
-  workSpaceName: z.string().optional(), // for multi-workspace support. If you want to use the multiple workspaces, you need to set the workSpaceName
+  workspaceId: z.string().optional(), // for multi-workspace support. If you want to use the multiple workspaces, you need to set the workspaceId
+  workspaceName: z.string().optional(), // for multi-workspace support. If you want to use the multiple workspaces, you need to set the workspaceName
 });
 export type SlackPluginConfigInput = z.input<typeof SlackPluginConfig>;
 export type SlackPluginConfig = z.output<typeof SlackPluginConfig>;

--- a/plugins/slack/src/database/oauthState.test.ts
+++ b/plugins/slack/src/database/oauthState.test.ts
@@ -33,6 +33,7 @@ describe("Testing oauthState", () => {
         sessionKey: "",
         stampUserId: stampUserId,
         expirationTime: expirationTime,
+        pluginId: "slack",
       };
       const resultAsync = setOauthState(logger, tableName, config)(input);
       const result = await resultAsync;
@@ -45,6 +46,7 @@ describe("Testing oauthState", () => {
         sessionKey: sessionKey,
         stampUserId: stampUserId,
         expirationTime: expirationTime,
+        pluginId: "slack",
       };
       const expected = structuredClone(input);
       const resultAsync = setOauthState(logger, tableName, config)(input);
@@ -63,6 +65,7 @@ describe("Testing oauthState", () => {
           sessionKey: sessionKey,
           stampUserId: "",
           expirationTime: expirationTime,
+          pluginId: "slack",
         },
       ],
       [
@@ -72,6 +75,7 @@ describe("Testing oauthState", () => {
           sessionKey: sessionKey,
           stampUserId: stampUserId,
           expirationTime: expirationTime,
+          pluginId: "slack",
         },
       ],
     ])("returns failure result", async (key, input) => {
@@ -91,6 +95,7 @@ describe("Testing oauthState", () => {
         sessionKey: sessionKey,
         stampUserId: stampUserId,
         expirationTime: expirationTime,
+        pluginId: "slack",
       };
       const resultAsync = getOauthState(logger, tableName, config)(input);
       const result = await resultAsync;

--- a/plugins/slack/src/database/oauthState.ts
+++ b/plugins/slack/src/database/oauthState.ts
@@ -12,6 +12,7 @@ export const OauthState = z.object({
   sessionKey: z.string(),
   stampUserId: UserId,
   expirationTime: z.number(),
+  pluginId: z.string(),
 });
 export type OauthState = z.infer<typeof OauthState>;
 

--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -35,6 +35,8 @@ export function createSlackPlugin(config: SlackPluginConfigInput) {
   const parsedConfig = SlackPluginConfig.parse(config);
   const logger = createLogger(parsedConfig.logLevel, { moduleName: "slack" });
   const slackEventPath = parsedConfig.basePath + "/event";
+  const pluginId = parsedConfig.workSpaceId ? `slack-${parsedConfig.workSpaceId}` : "slack";
+  const pluginName = parsedConfig.workSpaceName ? `Slack (${parsedConfig.workSpaceName})` : "Slack";
   const slackApp = new SlackApp({
     env: {
       SLACK_SIGNING_SECRET: parsedConfig.slackSigningSecret,
@@ -47,7 +49,7 @@ export function createSlackPlugin(config: SlackPluginConfigInput) {
     },
   });
   const stampHubClient = createStampHubHTTPServerClient(parsedConfig.stampHubUrl);
-  const getAccountLinkWithLogger = getAccountLink(logger, stampHubClient.systemRequest.accountLink.get);
+  const getAccountLinkWithLogger = getAccountLink(logger, stampHubClient.systemRequest.accountLink.get, pluginId);
   const getRequestInfoWithLogger = getRequestInfo(logger, stampHubClient.userRequest.approvalRequest.get);
 
   slackApp.event("message", async (req) => {
@@ -86,7 +88,7 @@ export function createSlackPlugin(config: SlackPluginConfigInput) {
     return await slackApp.run(rawReq);
   };
 
-  const accountLinkRouter = createAccountLinkRouter(logger, parsedConfig);
+  const accountLinkRouter = createAccountLinkRouter(logger, parsedConfig, pluginId);
 
   const router = new Hono();
   router.all("/event/*", (c) => {
@@ -94,7 +96,13 @@ export function createSlackPlugin(config: SlackPluginConfigInput) {
   });
   router.route("/account-link", accountLinkRouter);
 
-  const notificationPluginConfig: NotificationPluginConfig = createStampNotificationPlugin(parsedConfig.slackBotToken, parsedConfig.logLevel, stampHubClient);
+  const notificationPluginConfig: NotificationPluginConfig = createStampNotificationPlugin({
+    slackBotToken: parsedConfig.slackBotToken,
+    logLevel: parsedConfig.logLevel,
+    stampHubRouterClient: stampHubClient,
+    pluginId: pluginId,
+    pluginName: pluginName,
+  });
 
   return { router, notificationPluginConfig };
 }

--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -35,8 +35,8 @@ export function createSlackPlugin(config: SlackPluginConfigInput) {
   const parsedConfig = SlackPluginConfig.parse(config);
   const logger = createLogger(parsedConfig.logLevel, { moduleName: "slack" });
   const slackEventPath = parsedConfig.basePath + "/event";
-  const pluginId = parsedConfig.workSpaceId ? `slack-${parsedConfig.workSpaceId}` : "slack";
-  const pluginName = parsedConfig.workSpaceName ? `Slack (${parsedConfig.workSpaceName})` : "Slack";
+  const pluginId = parsedConfig.workspaceId ? `slack-${parsedConfig.workspaceId}` : "slack";
+  const pluginName = parsedConfig.workspaceName ? `Slack (${parsedConfig.workspaceName})` : "Slack";
   const slackApp = new SlackApp({
     env: {
       SLACK_SIGNING_SECRET: parsedConfig.slackSigningSecret,

--- a/plugins/slack/src/stamp-front-plugin-handler/accountLink.ts
+++ b/plugins/slack/src/stamp-front-plugin-handler/accountLink.ts
@@ -10,21 +10,21 @@ import { unwrapOr } from "../utils/stampHubClient";
 
 const STATE_EXPIRED_TIME = 1000 * 60 * 5; // 5 minutes
 
-export function createAccountLinkRouter(logger: Logger, config: SlackPluginConfig) {
+export function createAccountLinkRouter(logger: Logger, config: SlackPluginConfig, pluginId: string) {
   const router = new Hono();
 
   router.get("/", async (c) => {
     const sessionKey = getCookie(c, "stampAccountLinkSessionKey");
 
     if (sessionKey) {
-      return startOauth(logger, c, config, sessionKey);
+      return startOauth(logger, c, config, pluginId, sessionKey);
     } else {
       return new Response("Bad request", { status: 400 });
     }
   });
 
   router.get("/oatuh_redirect", async (c) => {
-    const response = await oauthCallback(logger, c, config);
+    const response = await oauthCallback(logger, c, config, pluginId);
     if (response) {
       return response;
     }
@@ -42,12 +42,13 @@ export function createAccountLinkRouter(logger: Logger, config: SlackPluginConfi
   return router;
 }
 
-async function startOauth(logger: Logger, c: Context, config: SlackPluginConfig, sessionKey: string): Promise<Response> {
+async function startOauth(logger: Logger, c: Context, config: SlackPluginConfig, pluginId: string, sessionKey: string): Promise<Response> {
   const stampHubHTTPServerClient = await createStampHubHTTPServerClient(config.stampHubUrl);
   const accountLinkSession = await unwrapOr(stampHubHTTPServerClient.systemRequest.accountLinkSession.get.query({ sessionKey }), undefined);
   const dynamodbDBTableBaseName = `${config.dynamoDBTableNamePrefix}-${config.dynamoDBTableCategoryName}`;
-
-  if (accountLinkSession?.accountProviderName !== "slack") {
+  // accountProviderName is the same as the notificationPluginConfig ID.
+  const accountProviderName = pluginId;
+  if (accountLinkSession?.accountProviderName !== accountProviderName) {
     return new Response("Bad request", { status: 400 });
   }
 
@@ -61,6 +62,7 @@ async function startOauth(logger: Logger, c: Context, config: SlackPluginConfig,
     sessionKey,
     stampUserId: accountLinkSession.userId,
     expirationTime,
+    pluginId,
   });
   if (setStateResult.isErr()) {
     logger.error(setStateResult.error);
@@ -83,11 +85,13 @@ function generateRedirectUrl(config: SlackPluginConfig) {
   return `https://${config.hostDomain}${config.basePath}/account-link/oatuh_redirect`;
 }
 
-async function oauthCallback(logger: Logger, c: Context, config: SlackPluginConfig) {
+async function oauthCallback(logger: Logger, c: Context, config: SlackPluginConfig, pluginId: string) {
   const code = c.req.query("code");
   const state = c.req.query("state");
   const sessionKey = getCookie(c, "stampAccountLinkSessionKey");
   const dynamodbDBTableBaseName = `${config.dynamoDBTableNamePrefix}-${config.dynamoDBTableCategoryName}`;
+  // accountProviderName is the same as the notificationPluginConfig ID.
+  const accountProviderName = pluginId;
 
   if (!sessionKey || !code || !state) {
     return new Response("Bad request", { status: 400 });
@@ -102,6 +106,7 @@ async function oauthCallback(logger: Logger, c: Context, config: SlackPluginConf
   if (
     getOauthStateResult.value.isNone() ||
     getOauthStateResult.value.value.sessionKey !== sessionKey ||
+    getOauthStateResult.value.value.pluginId !== pluginId ||
     !isTimestampValid(getOauthStateResult.value.value.expirationTime)
   ) {
     return new Response("Bad request", { status: 400 });
@@ -136,7 +141,7 @@ async function oauthCallback(logger: Logger, c: Context, config: SlackPluginConf
   // Link Slack userId and stampHub userId.
   await stampHubHTTPServerClient.systemRequest.accountLink.set.mutate({
     userId: getOauthStateResult.value.value.stampUserId,
-    accountProviderName: "slack",
+    accountProviderName,
     accountId: slackUserId,
   });
 }

--- a/plugins/slack/src/stamp-hub/accountLink.test.ts
+++ b/plugins/slack/src/stamp-hub/accountLink.test.ts
@@ -7,6 +7,8 @@ import { getAccountLink, GetAccountLinkInput, AccountLink } from "./accountLink"
 const logger = createLogger("DEBUG", { moduleName: "slack" });
 const accountId = "test-slack-user";
 const userId = "test-user-id";
+const notificationPluginId = "slack";
+// accountProviderName is the same as the notificationPluginConfig ID.
 const accountProviderName = "slack";
 const createdAt = "2024-01-02T03:04:05.006Z";
 
@@ -30,7 +32,32 @@ describe("Testing accountLink", () => {
         userId: userId,
         createdAt: createdAt,
       };
-      const result = await getAccountLink(logger, getAccountLinkClient)(input);
+      const result = await getAccountLink(logger, getAccountLinkClient, notificationPluginId)(input);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value).toEqual(some(expected));
+    });
+
+    it("should get account link with variant notificationPluginId", async () => {
+      const getAccountLinkClient = {
+        query: vi.fn().mockResolvedValue({
+          accountProviderName: "slack-variant-workspace-id",
+          accountId: accountId,
+          userId: userId,
+          createdAt: createdAt,
+        }),
+      };
+      const input: GetAccountLinkInput = {
+        slackUserId: accountId,
+      };
+      const expected: AccountLink = {
+        accountProviderName: "slack-variant-workspace-id",
+        accountId: accountId,
+        userId: userId,
+        createdAt: createdAt,
+      };
+      const result = await getAccountLink(logger, getAccountLinkClient, "slack-variant-workspace-id")(input);
       if (result.isErr()) {
         throw result.error;
       }
@@ -44,7 +71,7 @@ describe("Testing accountLink", () => {
       const input: GetAccountLinkInput = {
         slackUserId: "non-existent-slack-user-id",
       };
-      const result = await getAccountLink(logger, getAccountLinkClient)(input);
+      const result = await getAccountLink(logger, getAccountLinkClient, notificationPluginId)(input);
       if (result.isErr()) {
         throw result.error;
       }
@@ -58,7 +85,7 @@ describe("Testing accountLink", () => {
       const input: GetAccountLinkInput = {
         slackUserId: "",
       };
-      const result = await getAccountLink(logger, getAccountLinkClient)(input);
+      const result = await getAccountLink(logger, getAccountLinkClient, notificationPluginId)(input);
       if (result.isOk()) {
         throw result.value;
       }
@@ -72,7 +99,7 @@ describe("Testing accountLink", () => {
       const input: GetAccountLinkInput = {
         slackUserId: userId,
       };
-      const result = await getAccountLink(logger, getAccountLinkClient)(input);
+      const result = await getAccountLink(logger, getAccountLinkClient, notificationPluginId)(input);
       if (result.isOk()) {
         throw result.value;
       }

--- a/plugins/slack/src/stamp-hub/accountLink.ts
+++ b/plugins/slack/src/stamp-hub/accountLink.ts
@@ -12,12 +12,14 @@ export type GetAccountLinkInput = { slackUserId: string };
 export type GetAccountLink = (getAccountLinkInput: GetAccountLinkInput) => ResultAsync<Option<AccountLink>, NotificationError>;
 
 export const getAccountLink =
-  (logger: Logger, getAccountLink: StampHubRouterClient["systemRequest"]["accountLink"]["get"]): GetAccountLink =>
+  (logger: Logger, getAccountLink: StampHubRouterClient["systemRequest"]["accountLink"]["get"], notificationPluginId: string): GetAccountLink =>
   (input: GetAccountLinkInput) => {
+    // accountProviderName is the same as the notificationPluginConfig ID.
+    const accountProviderName = notificationPluginId;
     const requestStampHub = async () => {
       const accountLink = await unwrapOr(
         getAccountLink.query({
-          accountProviderName: "slack",
+          accountProviderName,
           accountId: input.slackUserId,
         }),
         undefined

--- a/plugins/slack/src/stamp-notification-plugin/index.ts
+++ b/plugins/slack/src/stamp-notification-plugin/index.ts
@@ -4,15 +4,19 @@ import { sendChannelMessage, setChannel, unsetChannel } from "./channel";
 import { sendApprovalRequestNotification, sendGroupMemberAddedEvent, sendNotification, sendResourceAudit } from "./notification";
 import { StampHubRouterClient } from "@stamp-lib/stamp-hub";
 
-export const createStampNotificationPlugin = (
-  slackBotToken: string,
-  logLevel: LogLevel = "INFO",
-  stampHubRouterClient: StampHubRouterClient
-): NotificationPluginConfig => {
+export const createStampNotificationPlugin = (input: {
+  slackBotToken: string;
+  logLevel: LogLevel;
+  stampHubRouterClient: StampHubRouterClient;
+  pluginId: string;
+  pluginName: string;
+}): NotificationPluginConfig => {
+  const { slackBotToken, logLevel, stampHubRouterClient, pluginId, pluginName } = input;
+  const pluginDescription = `Notification plugin for ${pluginName}`;
   const notificationPluginConfig: NotificationPluginConfig = {
-    id: "slack",
-    name: "slack",
-    description: "Slack notification plugin",
+    id: pluginId,
+    name: pluginName,
+    description: pluginDescription,
     handlers: {
       setChannel: setChannel(logLevel, sendChannelMessage({ slackBotToken })),
       unsetChannel: unsetChannel(logLevel, sendChannelMessage({ slackBotToken })),

--- a/plugins/slack/src/stamp-notification-plugin/notification.test.ts
+++ b/plugins/slack/src/stamp-notification-plugin/notification.test.ts
@@ -25,11 +25,12 @@ describe("sendNotification", () => {
   it("should route to sendResourceAudit", async () => {
     const sendResourceAudit = vi.fn().mockReturnValue(okAsync(undefined));
     const sendGroupMemberAddedEvent = vi.fn().mockReturnValue(okAsync(undefined));
-
+    const sendApprovalRequestNotification = vi.fn().mockReturnValue(okAsync(undefined));
     const result = await sendNotification({
       logLevel: "DEBUG",
       sendResourceAudit: sendResourceAudit,
       sendGroupMemberAddedEvent: sendGroupMemberAddedEvent,
+      sendApprovalRequestNotification: sendApprovalRequestNotification,
     })({
       message: {
         type: "ResourceAudit",
@@ -61,11 +62,12 @@ describe("sendNotification", () => {
   it("should route to sendGroupMemberAddedEvent", async () => {
     const sendResourceAudit = vi.fn().mockReturnValue(okAsync(undefined));
     const sendGroupMemberAddedEvent = vi.fn().mockReturnValue(okAsync(undefined));
-
+    const sendApprovalRequestNotification = vi.fn().mockReturnValue(okAsync(undefined));
     const result = await sendNotification({
       logLevel: "DEBUG",
       sendResourceAudit: sendResourceAudit,
       sendGroupMemberAddedEvent: sendGroupMemberAddedEvent,
+      sendApprovalRequestNotification: sendApprovalRequestNotification,
     })({
       message: {
         type: "GroupMemberAddedEvent",


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### 🎉 Reason for this change

<!--What is the bug or use case behind this change?-->

Add multi-workspace support to Slack plugin.

### 🔀 Description of changes

<!--What code changes did you make? Have you made any important design decisions?-->

This pull request introduces several changes to enhance the notification system and add support for multiple Slack workspaces. The key changes include updating the notification type handling, modifying the configuration for multi-workspace support, and updating the OAuth state management.

#### Notification Type Handling:

* [`apps/web-ui/src/app/account/settings/page.tsx`](diffhunk://#diff-e53f2bfeaf8afeee6e4e337adb704176e9e0c2c310e06ce113781de280c0e1daR24-R25): Added fetching of notification types and dynamically rendering them in the `AccountLink` component. [[1]](diffhunk://#diff-e53f2bfeaf8afeee6e4e337adb704176e9e0c2c310e06ce113781de280c0e1daR24-R25) [[2]](diffhunk://#diff-e53f2bfeaf8afeee6e4e337adb704176e9e0c2c310e06ce113781de280c0e1daL32-R43)
* [`apps/web-ui/src/components/group/approvalRequestNotificationDialog.tsx`](diffhunk://#diff-126968e87fb646c279f3e1fa5b5eb7d0c7e6c4b1c05470794b311114cb848a29L115-R118): Updated the `NotificationPropertyForm` to initialize the selected notification type based on existing approval request notifications and wrapped dynamic content in a `Fragment`. [[1]](diffhunk://#diff-126968e87fb646c279f3e1fa5b5eb7d0c7e6c4b1c05470794b311114cb848a29L115-R118) [[2]](diffhunk://#diff-126968e87fb646c279f3e1fa5b5eb7d0c7e6c4b1c05470794b311114cb848a29R158) [[3]](diffhunk://#diff-126968e87fb646c279f3e1fa5b5eb7d0c7e6c4b1c05470794b311114cb848a29R226)
* [`apps/web-ui/src/components/group/groupMemberNotificationDialog.tsx`](diffhunk://#diff-70cf6659329de05418a36bb4de83ec6595f73d5a22df0e191bd2af46ee6a66d4L114-R117): Similar updates as above for group member notifications. [[1]](diffhunk://#diff-70cf6659329de05418a36bb4de83ec6595f73d5a22df0e191bd2af46ee6a66d4L114-R117) [[2]](diffhunk://#diff-70cf6659329de05418a36bb4de83ec6595f73d5a22df0e191bd2af46ee6a66d4L153-R156) [[3]](diffhunk://#diff-70cf6659329de05418a36bb4de83ec6595f73d5a22df0e191bd2af46ee6a66d4R224)

#### Multi-Workspace Support:

* [`plugins/slack/README.md`](diffhunk://#diff-4e52ccdf604d3eb3a957bb7ef74f57986af1c1ea051d58198037ed3f78e610e6R9-R69): Added documentation on how to configure multiple instances of the Slack plugin for different workspaces.
* [`plugins/slack/src/config.ts`](diffhunk://#diff-3cc26b186273a7f70c6afeebd6002acff3084968c1e93f12e974a9f511854bc9R15-R16): Updated Slack plugin configuration to include optional `workSpaceId` and `workSpaceName` fields for multi-workspace support.
* [`plugins/slack/src/index.ts`](diffhunk://#diff-51bda7738d903d4212d97ccd3a4ab545408bd37fa9d28cba0b067b63ef8796e7R38-R39): Modified the Slack plugin creation function to handle multiple workspaces by setting unique `pluginId` and `pluginName` for each instance. [[1]](diffhunk://#diff-51bda7738d903d4212d97ccd3a4ab545408bd37fa9d28cba0b067b63ef8796e7R38-R39) [[2]](diffhunk://#diff-51bda7738d903d4212d97ccd3a4ab545408bd37fa9d28cba0b067b63ef8796e7L50-R52) [[3]](diffhunk://#diff-51bda7738d903d4212d97ccd3a4ab545408bd37fa9d28cba0b067b63ef8796e7L89-R105)

#### OAuth State Management:

* [`plugins/slack/src/database/oauthState.test.ts`](diffhunk://#diff-28b0a2cc146f28a7d8d84e7a1561921896bc5e788a5c9f11518f0439380a345fR36): Updated tests to include `pluginId` in the OAuth state. [[1]](diffhunk://#diff-28b0a2cc146f28a7d8d84e7a1561921896bc5e788a5c9f11518f0439380a345fR36) [[2]](diffhunk://#diff-28b0a2cc146f28a7d8d84e7a1561921896bc5e788a5c9f11518f0439380a345fR49) [[3]](diffhunk://#diff-28b0a2cc146f28a7d8d84e7a1561921896bc5e788a5c9f11518f0439380a345fR68) [[4]](diffhunk://#diff-28b0a2cc146f28a7d8d84e7a1561921896bc5e788a5c9f11518f0439380a345fR78) [[5]](diffhunk://#diff-28b0a2cc146f28a7d8d84e7a1561921896bc5e788a5c9f11518f0439380a345fR98)
* [`plugins/slack/src/database/oauthState.ts`](diffhunk://#diff-9f0693a8962a08edacf72fbaa71b80dec6a8926f6045397e13f68209a4ac85d8R15): Added `pluginId` to the OAuth state schema.
* [`plugins/slack/src/stamp-front-plugin-handler/accountLink.ts`](diffhunk://#diff-73e14b855645f4627f38a1f0c17e4687dc479c44577f8814f516fa04012b4389L13-R27): Updated account link router and OAuth callback functions to handle `pluginId` for multi-workspace support. [[1]](diffhunk://#diff-73e14b855645f4627f38a1f0c17e4687dc479c44577f8814f516fa04012b4389L13-R27) [[2]](diffhunk://#diff-73e14b855645f4627f38a1f0c17e4687dc479c44577f8814f516fa04012b4389L45-R51) [[3]](diffhunk://#diff-73e14b855645f4627f38a1f0c17e4687dc479c44577f8814f516fa04012b4389R65) [[4]](diffhunk://#diff-73e14b855645f4627f38a1f0c17e4687dc479c44577f8814f516fa04012b4389L86-R94) [[5]](diffhunk://#diff-73e14b855645f4627f38a1f0c17e4687dc479c44577f8814f516fa04012b4389R109)

### 🖨️ Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

Confirmed that the following unit tests pass.

- apps/web-ui
- plugins/slack

I have rewritten the code in apps/web-ui/custom-server/dynamodbApp.ts as below and confirmed that it works correctly.

<details>
  <summary> dynamodbApp.ts </summary>

  ```ts
import { createConfigProvider } from "@stamp-lib/stamp-config";
import { createDynamodbDBPlugin } from "@stamp-lib/stamp-dynamodb-db-plugin";
import { createDynamodbIdentityPlugin } from "@stamp-lib/stamp-dynamodb-identity-plugin";
import { unicornRentalCatalog } from "@stamp-lib/stamp-example-catalog";
import { createStampHubHTTPServer } from "@stamp-lib/stamp-hub";
import { createLogger, LogLevel } from "@stamp-lib/stamp-logger";
import { createPluginRouter } from "@stamp-lib/stamp-plugin-router";
import { serve } from "@hono/node-server";
import { createServer } from "node:http";
import { createStampServer } from "./stampServer";
import { createSlackPlugin } from "@stamp-lib/stamp-slack-plugin";
async function main() {
  const logLevel: LogLevel = (process.env.LOG_LEVEL as LogLevel) || "INFO";
  const logger = createLogger(logLevel, { moduleName: "web-ui" });

  const dynamodbDB = createDynamodbDBPlugin({
    region: "us-west-2",
    tableNamePrefix: process.env.DYNAMO_TABLE_PREFIX!,
    logLevel: logLevel,
  });

  const dynamodBIdentity = createDynamodbIdentityPlugin({
    region: "us-west-2",
    tableNamePrefix: process.env.DYNAMO_TABLE_PREFIX!,
    logLevel: logLevel,
  });

  const slackPluginA = await createSlackPlugin({
    slackSigningSecret: process.env.SLACK_SIGNING_SECRET!,
    slackBotToken: process.env.SLACK_BOT_TOKEN!,
    slackVerificationToken: process.env.SLACK_VERIFICATION_TOKEN!,
    slackClientId: process.env.SLACK_CLIENT_ID!,
    slackClientSecret: process.env.SLACK_CLIENT_SECRET!,
    hostDomain: process.env.HOST_DOMAIN!,
    basePath: "/plugin/slack-workspace-a",
    stampHubUrl: "http://localhost:4000",
    dynamoDBTableNamePrefix: process.env.DYNAMO_TABLE_PREFIX!,
    region: "us-west-2",
    logLevel: "INFO",
    workSpaceId: "workspace-a",
    workSpaceName: "Workspace A",
  });

  const slackPluginB = await createSlackPlugin({
    slackSigningSecret: process.env.SLACK_SIGNING_SECRET!,
    slackBotToken: process.env.SLACK_BOT_TOKEN!,
    slackVerificationToken: process.env.SLACK_VERIFICATION_TOKEN!,
    slackClientId: process.env.SLACK_CLIENT_ID!,
    slackClientSecret: process.env.SLACK_CLIENT_SECRET!,
    hostDomain: process.env.HOST_DOMAIN!,
    basePath: "/plugin/slack-workspace-b",
    stampHubUrl: "http://localhost:4000",
    dynamoDBTableNamePrefix: process.env.DYNAMO_TABLE_PREFIX!,
    region: "us-west-2",
    logLevel: "INFO",
    workSpaceId: "workspace-b",
    workSpaceName: "Workspace B",
  });

  const config = await createConfigProvider({
    catalogs: [unicornRentalCatalog],
    notificationPlugins: [slackPluginA.notificationPluginConfig, slackPluginB.notificationPluginConfig],
  });
  createStampHubHTTPServer({ db: dynamodbDB, config: config, identity: dynamodBIdentity }, 4000);

  const pluginRouter = createPluginRouter({
    basePath: "/plugin",
    plugins: {
      "slack-workspace-a": slackPluginA.router,
      "slack-workspace-b": slackPluginB.router,
    },
  });

  const createServerHttp: typeof createServer = await createStampServer();
  const serverOptions = {
    fetch: pluginRouter.fetch,
    port: 3000,
    createServer: createServerHttp,
  };
  serve(serverOptions, (info) => {
    logger.info(`Listening on http://localhost:${info.port}`);
  });
}

main();

```

The screenshot of the confirmed operation is below.

<img width="528" alt="スクリーンショット 2025-03-24 19 56 23" src="https://github.com/user-attachments/assets/819c1db5-9c06-4f53-a872-4f560ab1dd5e" />

<img width="576" alt="スクリーンショット 2025-03-24 20 48 07" src="https://github.com/user-attachments/assets/8bba88ca-e063-4ef3-b93d-ae033be99a6d" />



</details>

### 👀 Points to be checked especially by reviewers (if any)

<!--Describe any particular points you would like reviewers to check.-->

### 🔗 Related links

<!--Please include any relevant links -->
