### PR TITLE
Increase max length of value in ApprovalRequestInputParam from 128 to 4096

### DIFF
--- a/packages/types/src/models/approvalRequest.ts
+++ b/packages/types/src/models/approvalRequest.ts
@@ -4,7 +4,7 @@ import { ApprovalFlowId } from "./id";
 import { UserId } from "../pluginInterface/identity";
 export const ApprovalRequestInputParam = z.object({
   id: z.string().max(128),
-  value: z.union([z.string().max(128), z.number(), z.boolean()]),
+  value: z.union([z.string().max(4096), z.number(), z.boolean()]),
 });
 export type ApprovalRequestInputParam = z.infer<typeof ApprovalRequestInputParam>;
 


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### 🎉 Reason for this change

<!--What is the bug or use case behind this change?-->

This change addresses an issue related to https://github.com/sony/stamp/issues/21 .
In `packages/hub/src/workflows/resource/updateResourceParamsWithApproval/execution.ts`, the value sent as part of the approval workflow (value: JSON.stringify(input.updateParams)) can sometimes exceed 128 characters. Previously, when this value was too short or too long, resource update requests could result in errors.

https://github.com/sony/stamp/blob/18b1f4e7e58b74319a53da54337a0d595c60b6ec/packages/hub/src/workflows/resource/updateResourceParamsWithApproval/execution.ts#L73

This update ensures that values exceeding 128 characters are properly handled, improving the reliability of resource updates and aligning with the requirements discussed in issue #21.


### 🔀 Description of changes

<!--What code changes did you make? Have you made any important design decisions?-->

- Updated the code to support updateParams values exceeding 128 characters when sending to the approval workflow.

### 🖨️ Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

- Validation was performed by confirming that both npm run build and npx vitest run completed successfully.


### 👀 Points to be checked especially by reviewers (if any)

<!--Describe any particular points you would like reviewers to check.-->

### 🔗 Related links

<!--Please include any relevant links -->
