### PR TITLE
Update cancelUpdateResourceParamsWithApproval to handle rejected approval requests

### DIFF
--- a/packages/hub/src/workflows/resource/cancelUpdateResourceParamsWithApproval.ts
+++ b/packages/hub/src/workflows/resource/cancelUpdateResourceParamsWithApproval.ts
@@ -77,9 +77,9 @@ export const cancelUpdateResourceParamsWithApproval =
                 pendingUpdateParams: undefined, // Clear pending update params
               });
             });
-          } else if (approval.status === "approvedActionFailed") {
-            // If the approval request is already approved with action failed, we clear the pending update params
-            logger.info("Approval request is already approved with action failed, clearing pending update params");
+          } else if (approval.status === "approvedActionFailed" || approval.status === "rejected") {
+            // If the approval request is already approved with action failed or rejected, we clear the pending update params
+            logger.info("Approval request is already approved with action failed or rejected, clearing pending update params");
             return resourceDBProvider.updatePendingUpdateParams({
               catalogId: input.catalogId,
               resourceTypeId: input.resourceTypeId,
@@ -87,7 +87,7 @@ export const cancelUpdateResourceParamsWithApproval =
               pendingUpdateParams: undefined, // Clear pending update params
             });
           } else {
-            logger.warn("Approval request is not pending or approvedActionFailed, cannot cancel update", {
+            logger.warn("Approval request is not pending or approvedActionFailed or rejected, cannot cancel update", {
               approvalStatus: approval.status,
               catalogId: input.catalogId,
               resourceTypeId: input.resourceTypeId,
@@ -95,8 +95,8 @@ export const cancelUpdateResourceParamsWithApproval =
             });
             return errAsync(
               new StampHubError(
-                "Approval request is not pending or approvedActionFailed",
-                "Approval request is not pending or approvedActionFailed",
+                "Approval request is not pending or approvedActionFailed or rejected",
+                "Approval request is not pending or approvedActionFailed or rejected",
                 "BAD_REQUEST"
               )
             );


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### 🎉 Reason for this change

<!--What is the bug or use case behind this change?-->

Fixes a bug where cancelUpdateResourceParamsWithApproval did not work if there was a rejected approval request.

### 🔀 Description of changes

<!--What code changes did you make? Have you made any important design decisions?-->

- Updated logic so cancelUpdateResourceParamsWithApproval now properly handles rejected approval requests.


### 🖨️ Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

- Confirmed that all tests pass with `npx vitest run`.
- Confirmed that the build process completes successfully with `npm run build`.

### 👀 Points to be checked especially by reviewers (if any)

<!--Describe any particular points you would like reviewers to check.-->

### 🔗 Related links

<!--Please include any relevant links -->
