### PR TITLE
Remove permissionId from checkGroupExists input in tests and implementation

### DIFF
--- a/catalogs/iam-idc/src/events/group/checkGroupExists.test.ts
+++ b/catalogs/iam-idc/src/events/group/checkGroupExists.test.ts
@@ -60,7 +60,6 @@ describe("checkGroupExists", () => {
   it("should return error when group already exists", async () => {
     const input = {
       groupName: testGroupName,
-      permissionId: "test-permission-id",
     };
 
     const resultAsync = checkGroupExists(logger, config)(input);
@@ -78,7 +77,6 @@ describe("checkGroupExists", () => {
     const nonExistentGroupName = `Stamp-nonexistent-test-${Date.now()}`;
     const input = {
       groupName: nonExistentGroupName,
-      permissionId: "test-permission-id",
     };
 
     const resultAsync = checkGroupExists(logger, config)(input);
@@ -94,7 +92,6 @@ describe("checkGroupExists", () => {
     const upperCaseGroupName = testGroupName.toUpperCase();
     const input = {
       groupName: upperCaseGroupName,
-      permissionId: "test-permission-id",
     };
 
     const resultAsync = checkGroupExists(logger, config)(input);

--- a/catalogs/iam-idc/src/events/group/checkGroupExists.ts
+++ b/catalogs/iam-idc/src/events/group/checkGroupExists.ts
@@ -5,7 +5,6 @@ import { Logger } from "@stamp-lib/stamp-logger";
 type Config = { region: string; identityStoreId: string };
 type CheckGroupExistsInput = {
   groupName: string;
-  permissionId: string;
 };
 
 /**

--- a/catalogs/iam-idc/src/workflows/permission/createPermission.ts
+++ b/catalogs/iam-idc/src/workflows/permission/createPermission.ts
@@ -42,7 +42,6 @@ export const createPermission =
       const groupName = `${config.permissionIdPrefix}-${validateResult.permissionSetNameId}-${validateResult.awsAccountId}`;
       return checkGroupExistsFunc({
         groupName,
-        permissionId: validateResult.permissionId,
       })
         .mapErr((error) => {
           // Convert GroupExistsError to HandlerError with appropriate error code


### PR DESCRIPTION
### Issue # (if applicable)

Follow-up to #58

### 🎉 Reason for this change

In PR #58, the `checkGroupExists` function was introduced to validate group name uniqueness before permission creation. However, the `permissionId` parameter included in the function's input was not actually used within the implementation and was unnecessary.

### 🔀 Description of changes

- Removed unused `permissionId` parameter from `CheckGroupExistsInput` type definition
- Updated `checkGroupExists` function call in `createPermission` workflow to not pass `permissionId`
- Updated all test cases in `checkGroupExists.test.ts` to remove the unused parameter

**Files changed:**
- `catalogs/iam-idc/src/events/group/checkGroupExists.ts` - Removed `permissionId` from input type
- `catalogs/iam-idc/src/workflows/permission/createPermission.ts` - Removed `permissionId` from function call
- `catalogs/iam-idc/src/events/group/checkGroupExists.test.ts` - Updated all test cases

This is a pure cleanup change with no functional impact. The `checkGroupExists` function only needs the `groupName` to verify if a group already exists.

### 🖨️ Description of how you validated changes

- Verified that existing tests still pass
- Confirmed the function signature is cleaner and more focused on its single responsibility
- No behavioral changes to the group existence check logic

### 👀 Points to be checked especially by reviewers (if any)

- Confirm that `permissionId` was indeed not used anywhere in the `checkGroupExists` implementation
- Verify that all call sites have been updated correctly

### 🔗 Related links

- PR #58: Add group existence check and refactor permission workflows