### PR TITLE
Fix timezone handling in autoRevoke tests by calculating expected times dynamically

### DIFF
--- a/packages/hub/src/events/approval-request/actions/autoRevoke.test.ts
+++ b/packages/hub/src/events/approval-request/actions/autoRevoke.test.ts
@@ -95,6 +95,16 @@ describe("settingAutoRevoke", () => {
     const result = await settingAutoRevoke(mockCreateSchedulerEvent, logger)(input);
 
     expect(result.isOk()).toBeTruthy();
+    // formatDateForScheduler uses local timezone, so we calculate expected time accordingly
+    const expectedDate = new Date("2023-01-01T12:00:00Z");
+    expectedDate.setDate(expectedDate.getDate() + 5);
+    const expectedTime = `${expectedDate.getFullYear()}-${String(expectedDate.getMonth() + 1).padStart(2, "0")}-${String(expectedDate.getDate()).padStart(
+      2,
+      "0"
+    )}T${String(expectedDate.getHours()).padStart(2, "0")}:${String(expectedDate.getMinutes()).padStart(2, "0")}:${String(expectedDate.getSeconds()).padStart(
+      2,
+      "0"
+    )}`;
     expect(mockCreateSchedulerEvent).toHaveBeenCalledWith({
       eventType: "ApprovalRequestAutoRevoke",
       property: {
@@ -104,7 +114,7 @@ describe("settingAutoRevoke", () => {
       },
       schedulePattern: {
         type: "at",
-        time: "2023-01-06T21:00:00", // Add 5 days
+        time: expectedTime,
       },
     });
   });
@@ -122,6 +132,16 @@ describe("settingAutoRevoke", () => {
     const result = await settingAutoRevoke(mockCreateSchedulerEvent, logger)(input);
 
     expect(result.isOk()).toBeTruthy();
+    // formatDateForScheduler uses local timezone, so we calculate expected time accordingly
+    const expectedDate = new Date("2023-01-01T12:00:00Z");
+    expectedDate.setHours(expectedDate.getHours() + 8);
+    const expectedTime = `${expectedDate.getFullYear()}-${String(expectedDate.getMonth() + 1).padStart(2, "0")}-${String(expectedDate.getDate()).padStart(
+      2,
+      "0"
+    )}T${String(expectedDate.getHours()).padStart(2, "0")}:${String(expectedDate.getMinutes()).padStart(2, "0")}:${String(expectedDate.getSeconds()).padStart(
+      2,
+      "0"
+    )}`;
     expect(mockCreateSchedulerEvent).toHaveBeenCalledWith({
       eventType: "ApprovalRequestAutoRevoke",
       property: {
@@ -131,7 +151,7 @@ describe("settingAutoRevoke", () => {
       },
       schedulePattern: {
         type: "at",
-        time: "2023-01-02T05:00:00", // Add 8 hours
+        time: expectedTime,
       },
     });
   });
@@ -149,6 +169,17 @@ describe("settingAutoRevoke", () => {
     const result = await settingAutoRevoke(mockCreateSchedulerEvent, logger)(input);
 
     expect(result.isOk()).toBeTruthy();
+    // formatDateForScheduler uses local timezone, so we calculate expected time accordingly
+    const expectedDate = new Date("2023-01-01T12:00:00Z");
+    expectedDate.setDate(expectedDate.getDate() + 3);
+    expectedDate.setHours(expectedDate.getHours() + 12);
+    const expectedTime = `${expectedDate.getFullYear()}-${String(expectedDate.getMonth() + 1).padStart(2, "0")}-${String(expectedDate.getDate()).padStart(
+      2,
+      "0"
+    )}T${String(expectedDate.getHours()).padStart(2, "0")}:${String(expectedDate.getMinutes()).padStart(2, "0")}:${String(expectedDate.getSeconds()).padStart(
+      2,
+      "0"
+    )}`;
     expect(mockCreateSchedulerEvent).toHaveBeenCalledWith({
       eventType: "ApprovalRequestAutoRevoke",
       property: {
@@ -158,7 +189,7 @@ describe("settingAutoRevoke", () => {
       },
       schedulePattern: {
         type: "at",
-        time: "2023-01-05T09:00:00", // Add 3 days and 12 hours
+        time: expectedTime,
       },
     });
   });


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### 🎉 Reason for this change

<!--What is the bug or use case behind this change?-->

The `settingAutoRevoke` tests in `autoRevoke.test.ts` were failing in UTC environments (e.g., dev containers, CI runners). The tests had hardcoded expected times assuming JST (UTC+9), causing a 9-hour mismatch when run in UTC.


### 🔀 Description of changes

<!--What code changes did you make? Have you made any important design decisions?-->

Updated the three failing tests to calculate expected times dynamically instead of using hardcoded values:
- `successfully creates a scheduler event with days duration`
- `successfully creates a scheduler event with hours duration`
- `successfully creates a scheduler event with days and hours duration`

The expected time is now calculated using the same logic as the implementation (`Date` object with local timezone methods), ensuring the test passes regardless of the runner's timezone.


### 🖨️ Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

- Ran `npx vitest run` in the packages/hub directory
- All 15 tests in `autoRevoke.test.ts` now pass
- Full test suite passes (473 tests)

### 👀 Points to be checked especially by reviewers (if any)

<!--Describe any particular points you would like reviewers to check.-->

### 🔗 Related links

<!--Please include any relevant links -->
