### PR TITLE
feat(iam-role): support multiple GitHub organizations via config allowlist

### DIFF
--- a/catalogs/iam-role/README.md
+++ b/catalogs/iam-role/README.md
@@ -3,3 +3,145 @@
 ### How to setup
 
 Deploy [cf-db-template.yaml (catalogs/iam-role)](./cf-db-template.yaml) to CloudFormation
+
+### Running tests
+
+This catalog ships two kinds of tests:
+
+1. **Pure unit tests** — no AWS access required. They exercise config parsing,
+   IAM role name building, and resource-output shaping.
+2. **Integration / end-to-end tests** — require real AWS resources (DynamoDB
+   tables provisioned via `cf-db-template.yaml`, the IAM Role Factory
+   provisioned via `cf-iam-role-factory-template.yaml`) and AWS credentials.
+
+#### Unit tests only (no AWS)
+
+```bash
+cd catalogs/iam-role
+npm ci
+
+# Run just the AWS-free unit tests
+npx vitest run \
+  src/config.test.ts \
+  src/events/resource/gitHubIamRole.unit.test.ts \
+  src/handlers/gitHubIamRoleResource.unit.test.ts
+```
+
+#### Full test suite (requires AWS)
+
+Before running, set these environment variables and provide AWS credentials
+(via `AWS_PROFILE`, `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, or any other
+standard AWS SDK credential source):
+
+| Variable | Description |
+| --- | --- |
+| `AWS_ACCOUNT_ID` | Target AWS account ID used by the tests |
+| `IAM_ROLE_FACTORY_AWS_ACCOUNT_ID` | Account hosting the IAM Role Factory |
+| `IAM_ROLE_DYNAMO_TABLE_PREFIX` | Prefix used in `cf-db-template.yaml` deployment (table names become `${prefix}-iam-role-XxxResource`) |
+| `GITHUB_ORG_NAME` | A GitHub Organization name fixture tests can use |
+| `GITHUB_IAM_ROLE_ATTACHED_POLICY_ARN` | ARN of a managed policy that integration tests can attach |
+| `JUMP_IAM_ROLE_ATTACHED_POLICY_ARN` | ARN of a managed policy used by `jump-iam-role` tests |
+| `ORIGIN_IAM_ROLE_ARN` | ARN of an IAM role used as the trust origin in `jump-iam-role` tests |
+
+Then run:
+
+```bash
+cd catalogs/iam-role
+npm ci
+
+# Build once (some tests rely on the compiled output)
+npm run build
+
+# Run the entire suite
+npm test
+
+# Or run a specific file
+npx vitest run src/handlers/gitHubIamRoleResource.test.ts
+```
+
+The integration tests create and tear down real AWS resources (IAM roles,
+DynamoDB items). Make sure the AWS account is dedicated to testing and that
+the configured role-name / policy-name prefixes do not collide with anything
+in use.
+
+**Serial execution is required and enforced by `vitest.config.ts`**
+(`fileParallelism: false`). Several integration tests across files share
+the same IAM role names (e.g. `<roleNamePrefix>-github-<org>-<repo>`) to
+exercise realistic create/delete/audit flows; running test files in
+parallel would race on those AWS resources and produce intermittent
+`EntityAlreadyExists` / `NoSuchEntity` failures. The same config also
+bumps `hookTimeout` to 120s because `beforeAll` / `afterAll` perform
+multiple sequential AWS calls.
+
+If a previous test run was killed mid-flight you may also have orphaned
+IAM roles (matching `<roleNamePrefix>-github-*` and
+`<roleNamePrefix>-jump-*`). Delete them manually once before re-running
+the suite.
+
+### Configuration
+
+The catalog is configured via `createIamRoleCatalog(config)`.
+
+#### GitHub Organizations (multi-org support)
+
+A `github-iam-role` resource is always associated with a single GitHub
+Organization. To prevent typos from creating an IAM role whose trust policy
+trusts an unintended organization, this catalog **does not** accept free-form
+organization names from users. Instead, the catalog configuration declares an
+allow-list of organizations, and at resource creation time the user must pick
+one of them.
+
+##### `gitHubOrgNames`
+
+```ts
+createIamRoleCatalog({
+  // ...other fields...
+  gitHubOrgNames: ["my-org", "my-other-org"],
+});
+```
+
+When a user creates a `github-iam-role` resource they choose `gitHubOrgName`
+(required) and `repositoryName`. The handler rejects any value not in
+`gitHubOrgNames`.
+
+### Behavior notes
+
+- IAM role name format remains `${roleNamePrefix}-github-${gitHubOrgName}-${repositoryName}`
+  (the org name is taken from the per-resource choice, not from a single
+  config field). The 64-character IAM role name limit still applies; pick
+  shorter `roleNamePrefix` / repo names when on-boarding orgs with long names.
+- New resources created under multi-org support use a compound `resourceId` of
+  the form `${gitHubOrgName}/${repositoryName}` so that the same repository
+  name can be on-boarded under different orgs. Resources created before
+  multi-org support keep their bare `${repositoryName}` resourceId; both are
+  resolved correctly by `getResource` / `deleteResource` / promote requests.
+- DynamoDB schema (`cf-db-template.yaml`) is unchanged. New attributes
+  (`gitHubRepositoryName`, `gitHubOrgName`) are written to records created with
+  multi-org support; legacy records without those attributes are still readable.
+  Note that legacy records expose `gitHubOrgName` as `undefined` (the org cannot
+  be safely inferred — a silent fallback could mislead operators), so consumers
+  must handle the missing value. The bare `repositoryName` for legacy records is
+  derived exactly from the DynamoDB primary key.
+- List/search by name prefix matches against both the legacy bare
+  `repositoryName` and the new `gitHubRepositoryName` attribute, so typing a
+  repository name finds resources regardless of whether they were created
+  before or after the multi-org migration.
+- The user-visible `name` of a multi-org resource is `${gitHubOrgName}/${repositoryName}`
+  so identically named repositories under different orgs remain
+  distinguishable in selectors. Legacy single-org records keep their bare
+  repository name as the display name.
+
+### Caveats
+
+- The current `ResourceCreateParam` schema in `@stamp-lib/stamp-types` only
+  supports primitive types (no `enum`), so the web UI still presents
+  `gitHubOrgName` as a free-text input. The catalog handler validates the
+  value against `gitHubOrgNames` server-side and rejects anything not on the
+  allow-list, so the allow-list is enforced — but UX could be improved by
+  promoting `ResourceCreateParam` to support enum selection (out of scope for
+  this catalog).
+- Because new resourceIds contain a `/`, anywhere the resourceId is
+  embedded in a URL must URL-encode it (`encodeURIComponent`). The Stamp
+  web-ui does this already, but custom integrations should be aware.
+
+

--- a/catalogs/iam-role/src/config.test.ts
+++ b/catalogs/iam-role/src/config.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { IamRoleCatalogConfig, IamRoleCatalogConfigInput } from "./config";
+
+const baseConfigInput = {
+  region: "us-west-2",
+  iamRoleFactoryAccountId: "123456789012",
+  iamRoleFactoryAccountRoleArn: "arn:aws:iam::123456789012:role/factory",
+  policyNamePrefix: "stamp",
+  roleNamePrefix: "stamp",
+  awsAccountResourceTableName: "t-aws",
+  targetIamRoleResourceTableName: "t-target",
+  gitHubIamRoleResourceTableName: "t-github",
+  jumpIamRoleResourceTableName: "t-jump",
+} satisfies Partial<IamRoleCatalogConfigInput>;
+
+describe("IamRoleCatalogConfig", () => {
+  it("accepts a single allowed org", () => {
+    const cfg = IamRoleCatalogConfig.parse({ ...baseConfigInput, gitHubOrgNames: ["org-a"] });
+    expect(cfg.gitHubOrgNames).toEqual(["org-a"]);
+  });
+
+  it("accepts multiple allowed orgs", () => {
+    const cfg = IamRoleCatalogConfig.parse({ ...baseConfigInput, gitHubOrgNames: ["org-a", "org-b"] });
+    expect(cfg.gitHubOrgNames).toEqual(["org-a", "org-b"]);
+  });
+
+  it("rejects when gitHubOrgNames is missing", () => {
+    const result = IamRoleCatalogConfig.safeParse(baseConfigInput);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty gitHubOrgNames array", () => {
+    const result = IamRoleCatalogConfig.safeParse({ ...baseConfigInput, gitHubOrgNames: [] });
+    expect(result.success).toBe(false);
+  });
+});

--- a/catalogs/iam-role/src/config.ts
+++ b/catalogs/iam-role/src/config.ts
@@ -4,7 +4,13 @@ export const IamRoleCatalogConfig = z.object({
   region: z.string(),
   iamRoleFactoryAccountId: z.string(),
   iamRoleFactoryAccountRoleArn: z.string(),
-  gitHubOrgName: z.string(),
+  /**
+   * Allow-list of GitHub organizations whose repositories can be on-boarded as
+   * `github-iam-role` resources. Users must pick one of these values when
+   * creating a resource. Configuring an explicit allow-list (instead of letting
+   * users type any org name) prevents typo-driven security incidents.
+   */
+  gitHubOrgNames: z.array(z.string().min(1)).nonempty(),
   policyNamePrefix: z.string(),
   roleNamePrefix: z.string(),
   awsAccountResourceTableName: z.string(),

--- a/catalogs/iam-role/src/events/database/gitHubIamRoleDB.test.ts
+++ b/catalogs/iam-role/src/events/database/gitHubIamRoleDB.test.ts
@@ -1,12 +1,13 @@
 import { none, some } from "@stamp-lib/stamp-option";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { GitHubIamRole } from "../../types/gitHubIamRole";
+import { CreatedGitHubIamRole, GitHubIamRole } from "../../types/gitHubIamRole";
 import {
   DeleteGitHubIamRoleDBItemInput,
   GetByIamRoleNameInput,
   GetGitHubIamRoleDBItemInput,
   GitHubRepositoryName,
   ListGitHubIamRoleDBItemInput,
+  buildGitHubIamRolePkValue,
   createGitHubIamRoleDBItem,
   deleteGitHubIamRoleDBItem,
   getByIamRoleName,
@@ -18,27 +19,30 @@ import { createLogger } from "@stamp-lib/stamp-logger";
 const tableName = `${process.env.IAM_ROLE_DYNAMO_TABLE_PREFIX}-iam-role-GitHubIamRoleResource`;
 const config = { region: "us-west-2" };
 const githubOrgName = process.env.GITHUB_ORG_NAME!;
+const testBareRepoName = "stamp-testRepository";
+const testPkValue = buildGitHubIamRolePkValue(githubOrgName, testBareRepoName);
 
 describe("Testing gitHubIamRoleDB", () => {
   const logger = createLogger("DEBUG", { moduleName: "iam-role" });
   beforeAll(async () => {
     const input: DeleteGitHubIamRoleDBItemInput = {
-      repositoryName: "stamp-testRepository",
+      repositoryName: testPkValue,
     };
     await deleteGitHubIamRoleDBItem(logger, tableName, config)(input);
   });
 
   afterAll(async () => {
     const input: DeleteGitHubIamRoleDBItemInput = {
-      repositoryName: "stamp-testRepository",
+      repositoryName: testPkValue,
     };
     await deleteGitHubIamRoleDBItem(logger, tableName, config)(input);
   });
 
   describe("createGitHubIamRoleDBItem", () => {
     it("returns failed result if repository name is invalid", async () => {
-      const input: GitHubIamRole = {
+      const input: CreatedGitHubIamRole = {
         repositoryName: "",
+        gitHubOrgName: githubOrgName,
         iamRoleName: `test-github-${githubOrgName}-test-repository`,
         iamRoleArn: "arn:aws:iam::123456789012:role/test-service-role",
         createdAt: "2024-01-02T03:04:05.006Z",
@@ -49,8 +53,9 @@ describe("Testing gitHubIamRoleDB", () => {
     });
 
     it("returns failed result even if iam role name is empty", async () => {
-      const input: GitHubIamRole = {
-        repositoryName: "stamp-testRepository",
+      const input: CreatedGitHubIamRole = {
+        repositoryName: testBareRepoName,
+        gitHubOrgName: githubOrgName,
         iamRoleName: "",
         iamRoleArn: "arn:aws:iam::123456789012:role/test-service-role",
         createdAt: "2024-01-02T03:04:05.006Z",
@@ -61,8 +66,9 @@ describe("Testing gitHubIamRoleDB", () => {
     });
 
     it("returns successful result even if iam role arn is empty", async () => {
-      const input: GitHubIamRole = {
-        repositoryName: "stamp-testRepository",
+      const input: CreatedGitHubIamRole = {
+        repositoryName: testBareRepoName,
+        gitHubOrgName: githubOrgName,
         iamRoleName: `test-github-${githubOrgName}-test-repository`,
         iamRoleArn: "",
         createdAt: "2024-01-02T03:04:05.006Z",
@@ -73,8 +79,9 @@ describe("Testing gitHubIamRoleDB", () => {
     });
 
     it("returns failed result if creation date is invalid", async () => {
-      const input: GitHubIamRole = {
-        repositoryName: "stamp-testRepository",
+      const input: CreatedGitHubIamRole = {
+        repositoryName: testBareRepoName,
+        gitHubOrgName: githubOrgName,
         iamRoleName: `test-github-${githubOrgName}-test-repository`,
         iamRoleArn: "arn:aws:iam::123456789012:role/test-service-role",
         createdAt: "",
@@ -85,13 +92,21 @@ describe("Testing gitHubIamRoleDB", () => {
     });
 
     it("creates GitHub iam role DB item", async () => {
-      const input: GitHubIamRole = {
-        repositoryName: "stamp-testRepository",
+      const input: CreatedGitHubIamRole = {
+        repositoryName: testBareRepoName,
+        gitHubOrgName: githubOrgName,
         iamRoleName: `test-github-${githubOrgName}-test-repository`,
         iamRoleArn: "arn:aws:iam::123456789012:role/test-service-role",
         createdAt: "2024-01-02T03:04:05.006Z",
       };
-      const expected = structuredClone(input);
+      const expected: GitHubIamRole = {
+        repositoryName: testPkValue,
+        gitHubRepositoryName: testBareRepoName,
+        gitHubOrgName: githubOrgName,
+        iamRoleName: `test-github-${githubOrgName}-test-repository`,
+        iamRoleArn: "arn:aws:iam::123456789012:role/test-service-role",
+        createdAt: "2024-01-02T03:04:05.006Z",
+      };
       const resultAsync = createGitHubIamRoleDBItem(logger, tableName, config)(input);
       const result = await resultAsync;
       if (result.isErr()) {
@@ -105,10 +120,12 @@ describe("Testing gitHubIamRoleDB", () => {
   describe("getGitHubIamRoleDBItem", () => {
     it("gets GitHub iam role DB item", async () => {
       const input: GetGitHubIamRoleDBItemInput = {
-        repositoryName: "stamp-testRepository",
+        repositoryName: testPkValue,
       };
       const expected: GitHubIamRole = {
-        repositoryName: "stamp-testRepository",
+        repositoryName: testPkValue,
+        gitHubRepositoryName: testBareRepoName,
+        gitHubOrgName: githubOrgName,
         iamRoleArn: "arn:aws:iam::123456789012:role/test-service-role",
         iamRoleName: `test-github-${githubOrgName}-test-repository`,
         createdAt: "2024-01-02T03:04:05.006Z",
@@ -150,7 +167,7 @@ describe("Testing gitHubIamRoleDB", () => {
         iamRoleName: `test-github-${githubOrgName}-test-repository`,
       };
       const expected: GitHubRepositoryName = {
-        repositoryName: "stamp-testRepository",
+        repositoryName: testPkValue,
       };
 
       const resultAsync = getByIamRoleName(logger, tableName, config)(input);
@@ -200,7 +217,7 @@ describe("Testing gitHubIamRoleDB", () => {
   describe("deleteGitHubIamRoleDBItem", () => {
     it("deletes GitHub iam role DB item", async () => {
       const input: DeleteGitHubIamRoleDBItemInput = {
-        repositoryName: "stamp-testRepository",
+        repositoryName: testPkValue,
       };
       const resultAsync = deleteGitHubIamRoleDBItem(logger, tableName, config)(input);
       const result = await resultAsync;

--- a/catalogs/iam-role/src/events/database/gitHubIamRoleDB.ts
+++ b/catalogs/iam-role/src/events/database/gitHubIamRoleDB.ts
@@ -11,10 +11,31 @@ import {
   QueryCommand,
   QueryCommandInput,
 } from "@aws-sdk/lib-dynamodb";
-import { GitHubIamRole } from "../../types/gitHubIamRole";
+import { CreatedGitHubIamRole, GitHubIamRole } from "../../types/gitHubIamRole";
 import { Option, some, none } from "@stamp-lib/stamp-option";
 import { z } from "zod";
 import { Logger } from "@stamp-lib/stamp-logger";
+
+/**
+ * Builds the DynamoDB primary-key value (also the Stamp `resourceId`) for a
+ * GitHub IAM Role resource. With multi-org support the PK is the compound
+ * `${gitHubOrgName}/${repositoryName}` so that the same repo name can exist
+ * under different orgs without collision.
+ */
+export const buildGitHubIamRolePkValue = (gitHubOrgName: string, repositoryName: string): string => `${gitHubOrgName}/${repositoryName}`;
+
+/**
+ * Extracts the bare repository name from the persisted primary-key value.
+ * Multi-org records use the compound form `${org}/${repo}`; legacy single-org
+ * records store the bare repo name as PK directly. Neither GitHub org names
+ * nor repository names may contain `/`, so splitting on the first `/` is
+ * unambiguous. Useful when only the PK is available (e.g. when reading via
+ * the `IamRoleNameIndex` GSI which has `KEYS_ONLY` projection).
+ */
+export const extractBareRepositoryName = (pkValue: string): string => {
+  const idx = pkValue.indexOf("/");
+  return idx === -1 ? pkValue : pkValue.slice(idx + 1);
+};
 
 export type GetGitHubIamRoleDBItemInput = { repositoryName: string };
 export type GetGitHubIamRoleDBItem = (input: GetGitHubIamRoleDBItemInput) => ResultAsync<Option<GitHubIamRole>, HandlerError>;
@@ -56,14 +77,21 @@ export const listGitHubIamRoleDBItem =
   (logger: Logger, tableName: string, DynamoDBClientConfig = {}): ListGitHubIamRoleDBItem =>
   (input) => {
     const exclusiveStartKey = input.nextToken ? JSON.parse(atob(input.nextToken)) : undefined;
+    const namePrefix = input.namePrefix ?? "";
+    // Match either the PK (`repositoryName`) — which covers legacy bare-name
+    // records — or the explicit `gitHubRepositoryName` attribute introduced
+    // for multi-org records. This lets users search by bare repository name
+    // regardless of whether the resource was created before or after the
+    // multi-org migration.
     const param: ScanCommandInput = {
       TableName: tableName,
-      FilterExpression: "begins_with(#nm, :name)",
+      FilterExpression: "begins_with(#pk, :name) OR begins_with(#bare, :name)",
       ExpressionAttributeValues: {
-        ":name": input.namePrefix ?? "",
+        ":name": namePrefix,
       },
       ExpressionAttributeNames: {
-        "#nm": "repositoryName",
+        "#pk": "repositoryName",
+        "#bare": "gitHubRepositoryName",
       },
       Limit: input.limit ?? undefined,
       ExclusiveStartKey: exclusiveStartKey,
@@ -90,19 +118,38 @@ export const listGitHubIamRoleDBItem =
     });
   };
 
-export type CreateGitHubIamRoleDBItem = (input: GitHubIamRole) => ResultAsync<GitHubIamRole, HandlerError>;
+export type CreateGitHubIamRoleDBItem = (input: CreatedGitHubIamRole) => ResultAsync<GitHubIamRole, HandlerError>;
 
 export const createGitHubIamRoleDBItem =
   (logger: Logger, tableName: string, DynamoDBClientConfig = {}): CreateGitHubIamRoleDBItem =>
   (input) => {
-    const perseResult = GitHubIamRole.safeParse(input);
+    // Validate input first to surface bare-repo / org-level mistakes (e.g.
+    // empty strings) before we synthesize the compound PK. The persisted
+    // schema is intentionally lenient (it must accept legacy items missing
+    // these fields), so it would otherwise silently coerce an empty repo
+    // name into a `${org}/` PK.
+    const inputValidation = CreatedGitHubIamRole.safeParse(input);
+    if (!inputValidation.success) {
+      return errAsync(new HandlerError(`Failed to parse input.: ${inputValidation.error.toString()}`, "INTERNAL_SERVER_ERROR"));
+    }
+    // Persist with the compound primary key (`${org}/${bareRepo}`) so that
+    // resources with identical bare repo names across different orgs do not
+    // collide.
+    const itemInput: GitHubIamRole = {
+      repositoryName: buildGitHubIamRolePkValue(input.gitHubOrgName, input.repositoryName),
+      gitHubRepositoryName: input.repositoryName,
+      gitHubOrgName: input.gitHubOrgName,
+      iamRoleName: input.iamRoleName,
+      iamRoleArn: input.iamRoleArn,
+      createdAt: input.createdAt,
+    };
+    const perseResult = GitHubIamRole.safeParse(itemInput);
     if (!perseResult.success) {
       return errAsync(new HandlerError(`Failed to parse input.: ${perseResult.error.toString()}`, "INTERNAL_SERVER_ERROR"));
     }
-    const itemInput = perseResult.data;
     const param = {
       TableName: tableName,
-      Item: itemInput,
+      Item: perseResult.data,
     };
     const client = new DynamoDBClient(DynamoDBClientConfig);
     const ddbDocClient = DynamoDBDocumentClient.from(client);
@@ -113,7 +160,7 @@ export const createGitHubIamRoleDBItem =
       logger.error(errorMessage);
       return new HandlerError((err as Error).message ?? "Internal Server Error", "INTERNAL_SERVER_ERROR");
     }).andThen(() => {
-      return okAsync(itemInput);
+      return okAsync(perseResult.data);
     });
   };
 
@@ -144,6 +191,7 @@ export const deleteGitHubIamRoleDBItem =
 
 export const GitHubRepositoryName = z.object({
   repositoryName: z.string(),
+  gitHubRepositoryName: z.string().optional(),
 });
 export type GitHubRepositoryName = z.infer<typeof GitHubRepositoryName>;
 

--- a/catalogs/iam-role/src/events/iam-ops/assumeRolePolicy.test.ts
+++ b/catalogs/iam-role/src/events/iam-ops/assumeRolePolicy.test.ts
@@ -85,7 +85,7 @@ describe("AssumeRolePolicy", () => {
     expect(createAssumeRoleResult.isErr()).toBe(true);
   });
 
-  it("deleteAssumeRolePolicy event should return error if not created assume role policy.", async () => {
+  it("deleteAssumeRolePolicy event should be idempotent when policy does not exist", async () => {
     const iamClient = new IAMClient({ region: "us-west-2" });
     const deleteAssumeRoleResult = await deleteAssumeRolePolicy(
       logger,
@@ -93,7 +93,8 @@ describe("AssumeRolePolicy", () => {
     )({
       assumeRolePolicyArn: `arn:aws:iam::${testInput.targetAWSAccountId}:policy/this-is-not-exist`,
     });
-    expect(deleteAssumeRoleResult.isOk()).toBe(false);
+    // The policy does not exist on AWS; the delete should be a no-op.
+    expect(deleteAssumeRoleResult.isOk()).toBe(true);
   });
 
   it("listIamRoleAttachedAssumeRolePolicy should return empty array if not attached assume role policy.", async () => {

--- a/catalogs/iam-role/src/events/iam-ops/assumeRolePolicy.ts
+++ b/catalogs/iam-role/src/events/iam-ops/assumeRolePolicy.ts
@@ -73,11 +73,28 @@ export const deleteAssumeRolePolicy =
       PolicyArn: parsedInput.assumeRolePolicyArn,
     });
 
-    return ResultAsync.fromPromise(iamClient.send(deletePolicy), (error) => {
-      const errorMessage = `Failed to delete policy: ${error}`;
-      logger.error(errorMessage);
-      return new HandlerError(errorMessage, "INTERNAL_SERVER_ERROR");
-    }).map(() => {});
+    return ResultAsync.fromPromise(
+      iamClient.send(deletePolicy).then(
+        () => ({ ok: true as const }),
+        (error: unknown) => {
+          // Treat a missing IAM policy as success: the desired post-condition
+          // (policy no longer exists) already holds. Without this branch an
+          // orphaned DB record (where the IAM policy was deleted out-of-band)
+          // can never be cleaned up via the normal deleteResource path.
+          const name = (error as { name?: string } | undefined)?.name;
+          if (name === "NoSuchEntity" || name === "NoSuchEntityException") {
+            logger.info(`IAM policy ${parsedInput.assumeRolePolicyArn} already absent; treating delete as success`);
+            return { ok: true as const };
+          }
+          throw error;
+        }
+      ),
+      (error) => {
+        const errorMessage = `Failed to delete policy: ${error}`;
+        logger.error(errorMessage);
+        return new HandlerError(errorMessage, "INTERNAL_SERVER_ERROR");
+      }
+    ).map(() => {});
   };
 
 export const ListIamRoleAttachedAssumeRolePolicyCommand = z.object({

--- a/catalogs/iam-role/src/events/resource/gitHubIamRole.test.ts
+++ b/catalogs/iam-role/src/events/resource/gitHubIamRole.test.ts
@@ -20,7 +20,7 @@ const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: accountId,
   iamRoleFactoryAccountRoleArn: "test-arn",
-  gitHubOrgName: githubOrgName,
+  gitHubOrgNames: [githubOrgName],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   awsAccountResourceTableName: `${process.env.IAM_ROLE_DYNAMO_TABLE_PREFIX}-iam-role-AWSAccountResource`,
@@ -33,8 +33,9 @@ const config: IamRoleCatalogConfig = {
 const deleteGitHubIamRoleForTest = async (logger: Logger) => {
   const iamClient = new IAMClient({ region: "us-west-2" });
   const input: GitHubIamRole = {
+    gitHubOrgName: githubOrgName,
     repositoryName: "test-Repository",
-    iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgName}-test-Repository`,
+    iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgNames[0]}-test-Repository`,
     iamRoleArn: "test-arn",
     createdAt: "2024-01-02T03:04:05.006Z",
   };
@@ -54,11 +55,13 @@ describe("Testing gitHubIamRole", () => {
   describe("createGitHubIamRoleName", () => {
     it("creates GitHub iam role name if iam role name is 64 character or under", async () => {
       const input: CreateGitHubIamRoleNameCommand = {
+        gitHubOrgName: githubOrgName,
         repositoryName: "1".repeat(44), // number of characters within range excluding prefix etc
       };
       const expected: CreatedGitHubIamRoleName = {
+        gitHubOrgName: githubOrgName,
         repositoryName: "1".repeat(44), // number of characters within range excluding prefix etc
-        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgName}-` + "1".repeat(44),
+        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgNames[0]}-` + "1".repeat(44),
       };
       const result = createGitHubIamRoleName(config)(input);
       if (result.isErr()) {
@@ -69,6 +72,7 @@ describe("Testing gitHubIamRole", () => {
 
     it("returns failed result if iam role name is over 64 character", async () => {
       const input: CreateGitHubIamRoleNameCommand = {
+        gitHubOrgName: githubOrgName,
         repositoryName: "1".repeat(44) + "a", // number of characters exceeding range limit
       };
       const result = createGitHubIamRoleName(config)(input);
@@ -77,6 +81,7 @@ describe("Testing gitHubIamRole", () => {
 
     it("returns successful result even if repository name is empty", async () => {
       const input: CreateGitHubIamRoleNameCommand = {
+        gitHubOrgName: githubOrgName,
         repositoryName: "",
       };
       const result = createGitHubIamRoleName(config)(input);
@@ -89,12 +94,14 @@ describe("Testing gitHubIamRole", () => {
     it("creates GitHub iam role in AWS", async () => {
       const iamClient = new IAMClient({ region: "us-west-2" });
       const input: CreateGitHubIamRoleCommand = {
+        gitHubOrgName: githubOrgName,
         repositoryName: "test-Repository",
-        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgName}-test-Repository`,
+        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgNames[0]}-test-Repository`,
       };
       const expected: CreatedGitHubIamRole = {
+        gitHubOrgName: githubOrgName,
         repositoryName: "test-Repository",
-        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgName}-test-Repository`,
+        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgNames[0]}-test-Repository`,
         iamRoleArn: expect.any(String),
         createdAt: expect.any(String),
       };
@@ -109,8 +116,9 @@ describe("Testing gitHubIamRole", () => {
     it("returns failed result if repository name is invalid", async () => {
       const iamClient = new IAMClient({ region: "us-west-2" });
       const input: CreateGitHubIamRoleCommand = {
+        gitHubOrgName: githubOrgName,
         repositoryName: "",
-        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgName}-test-Repository`,
+        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgNames[0]}-test-Repository`,
       };
       const resultAsync = createGitHubIamRoleInAws(logger, config, iamClient)(input);
       const result = await resultAsync;
@@ -120,6 +128,7 @@ describe("Testing gitHubIamRole", () => {
     it("returns failed result if iam role name is invalid", async () => {
       const iamClient = new IAMClient({ region: "us-west-2" });
       const input: CreateGitHubIamRoleCommand = {
+        gitHubOrgName: githubOrgName,
         repositoryName: "test-Repository",
         iamRoleName: "",
       };
@@ -167,8 +176,9 @@ describe("Testing gitHubIamRole", () => {
     it("deletes GitHub iam role in AWS", async () => {
       const iamClient = new IAMClient({ region: "us-west-2" });
       const input: GitHubIamRole = {
+        gitHubOrgName: githubOrgName,
         repositoryName: "test-Repository",
-        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgName}-test-Repository`,
+        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgNames[0]}-test-Repository`,
         iamRoleArn: "test-arn",
         createdAt: "2024-01-02T03:04:05.006Z",
       };
@@ -181,22 +191,25 @@ describe("Testing gitHubIamRole", () => {
       expect(result.value).toEqual(expected);
     });
 
-    it("returns failed result if repository name is invalid", async () => {
+    it("returns ok when the IAM role for an invalid repository name does not exist (idempotent)", async () => {
       const iamClient = new IAMClient({ region: "us-west-2" });
       const input: GitHubIamRole = {
+        gitHubOrgName: githubOrgName,
         repositoryName: "",
-        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgName}-test-Repository`,
+        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgNames[0]}-test-Repository`,
         iamRoleArn: "test-arn",
         createdAt: "2024-01-02T03:04:05.006Z",
       };
       const resultAsync = deleteGitHubIamRoleInAws(logger, iamClient)(input);
       const result = await resultAsync;
-      expect(result.isErr()).toBe(true);
+      // The IAM role does not exist on AWS; the delete should be a no-op.
+      expect(result.isOk()).toBe(true);
     });
 
     it("returns failed result if iam role name is invalid", async () => {
       const iamClient = new IAMClient({ region: "us-west-2" });
       const input: GitHubIamRole = {
+        gitHubOrgName: githubOrgName,
         repositoryName: "test-Repository",
         iamRoleName: "",
         iamRoleArn: "test-arn",
@@ -207,30 +220,32 @@ describe("Testing gitHubIamRole", () => {
       expect(result.isErr()).toBe(true);
     });
 
-    it("returns failed result if iam role arn is invalid", async () => {
+    it("returns ok when the IAM role for an invalid iam role arn does not exist (idempotent)", async () => {
       const iamClient = new IAMClient({ region: "us-west-2" });
       const input: GitHubIamRole = {
+        gitHubOrgName: githubOrgName,
         repositoryName: "test-Repository",
-        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgName}-test-Repository`,
+        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgNames[0]}-test-Repository`,
         iamRoleArn: "",
         createdAt: "2024-01-02T03:04:05.006Z",
       };
       const resultAsync = deleteGitHubIamRoleInAws(logger, iamClient)(input);
       const result = await resultAsync;
-      expect(result.isErr()).toBe(true);
+      expect(result.isOk()).toBe(true);
     });
 
-    it("returns failed result if created date is invalid", async () => {
+    it("returns ok when the IAM role for an invalid created date does not exist (idempotent)", async () => {
       const iamClient = new IAMClient({ region: "us-west-2" });
       const input: GitHubIamRole = {
+        gitHubOrgName: githubOrgName,
         repositoryName: "test-Repository",
-        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgName}-test-Repository`,
+        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgNames[0]}-test-Repository`,
         iamRoleArn: "test-arn",
         createdAt: "",
       };
       const resultAsync = deleteGitHubIamRoleInAws(logger, iamClient)(input);
       const result = await resultAsync;
-      expect(result.isErr()).toBe(true);
+      expect(result.isOk()).toBe(true);
     });
   });
 });

--- a/catalogs/iam-role/src/events/resource/gitHubIamRole.test.ts
+++ b/catalogs/iam-role/src/events/resource/gitHubIamRole.test.ts
@@ -79,13 +79,13 @@ describe("Testing gitHubIamRole", () => {
       expect(result.isErr()).toBe(true);
     });
 
-    it("returns successful result even if repository name is empty", async () => {
+    it("returns BAD_REQUEST when repository name is empty (runtime schema validation)", async () => {
       const input: CreateGitHubIamRoleNameCommand = {
         gitHubOrgName: githubOrgName,
         repositoryName: "",
       };
       const result = createGitHubIamRoleName(config)(input);
-      expect(result.isOk()).toBe(true);
+      expect(result.isErr()).toBe(true);
     });
   });
 

--- a/catalogs/iam-role/src/events/resource/gitHubIamRole.ts
+++ b/catalogs/iam-role/src/events/resource/gitHubIamRole.ts
@@ -17,11 +17,22 @@ export type CreateGitHubIamRoleName = (input: CreateGitHubIamRoleNameCommand) =>
 export const createGitHubIamRoleName =
   (config: IamRoleCatalogConfig): CreateGitHubIamRoleName =>
   (input) => {
-    if (!config.gitHubOrgNames.includes(input.gitHubOrgName)) {
-      const message = `GitHub organization "${input.gitHubOrgName}" is not allowed. Allowed organizations: ${config.gitHubOrgNames.join(", ")}.`;
+    const parsedResult = CreateGitHubIamRoleNameCommand.safeParse(input);
+    if (!parsedResult.success) {
+      return err(
+        new HandlerError(
+          `Failed to parse input.: ${parsedResult.error}`,
+          "BAD_REQUEST",
+          `Failed to parse input.: ${parsedResult.error}. Please check input value.`
+        )
+      );
+    }
+    const parsedInput = parsedResult.data;
+    if (!config.gitHubOrgNames.includes(parsedInput.gitHubOrgName)) {
+      const message = `GitHub organization "${parsedInput.gitHubOrgName}" is not allowed. Allowed organizations: ${config.gitHubOrgNames.join(", ")}.`;
       return err(new HandlerError(message, "BAD_REQUEST", message));
     }
-    const iamRoleName = `${config.roleNamePrefix}-github-${input.gitHubOrgName}-${input.repositoryName}`;
+    const iamRoleName = `${config.roleNamePrefix}-github-${parsedInput.gitHubOrgName}-${parsedInput.repositoryName}`;
     if (iamRoleName.length > 64) {
       return err(
         new HandlerError(
@@ -32,8 +43,8 @@ export const createGitHubIamRoleName =
       );
     }
     return ok({
-      repositoryName: input.repositoryName,
-      gitHubOrgName: input.gitHubOrgName,
+      repositoryName: parsedInput.repositoryName,
+      gitHubOrgName: parsedInput.gitHubOrgName,
       iamRoleName,
     });
   };

--- a/catalogs/iam-role/src/events/resource/gitHubIamRole.ts
+++ b/catalogs/iam-role/src/events/resource/gitHubIamRole.ts
@@ -17,18 +17,23 @@ export type CreateGitHubIamRoleName = (input: CreateGitHubIamRoleNameCommand) =>
 export const createGitHubIamRoleName =
   (config: IamRoleCatalogConfig): CreateGitHubIamRoleName =>
   (input) => {
-    const iamRoleName = `${config.roleNamePrefix}-github-${config.gitHubOrgName}-${input.repositoryName}`;
+    if (!config.gitHubOrgNames.includes(input.gitHubOrgName)) {
+      const message = `GitHub organization "${input.gitHubOrgName}" is not allowed. Allowed organizations: ${config.gitHubOrgNames.join(", ")}.`;
+      return err(new HandlerError(message, "BAD_REQUEST", message));
+    }
+    const iamRoleName = `${config.roleNamePrefix}-github-${input.gitHubOrgName}-${input.repositoryName}`;
     if (iamRoleName.length > 64) {
       return err(
         new HandlerError(
           `Failed to create role name. ${iamRoleName} is over 64 character.`,
           "BAD_REQUEST",
-          `Failed to create role name. ${iamRoleName} is over 64 character. Please change repository name to short one.`
+          `Failed to create role name. ${iamRoleName} is over 64 character. Please use a shorter repository name or a GitHub organization with a shorter name.`
         )
       );
     }
     return ok({
       repositoryName: input.repositoryName,
+      gitHubOrgName: input.gitHubOrgName,
       iamRoleName,
     });
   };
@@ -61,7 +66,7 @@ export const createGitHubIamRoleInAws =
           Action: "sts:AssumeRoleWithWebIdentity",
           Condition: {
             StringLike: {
-              "token.actions.githubusercontent.com:sub": `repo:${config.gitHubOrgName}/${parsedInput.repositoryName}:*`,
+              "token.actions.githubusercontent.com:sub": `repo:${parsedInput.gitHubOrgName}/${parsedInput.repositoryName}:*`,
             },
           },
         },
@@ -93,11 +98,30 @@ export const deleteGitHubIamRoleInAws =
       RoleName: input.iamRoleName,
     });
 
-    return ResultAsync.fromPromise(iamClient.send(deleteRole), (error) => {
-      const errorMessage = `Failed to delete role: ${error}`;
-      logger.error(errorMessage);
-      return new HandlerError(errorMessage, "INTERNAL_SERVER_ERROR");
-    }).map(() => input);
+    return ResultAsync.fromPromise(
+      iamClient.send(deleteRole).then(
+        () => ({ ok: true as const }),
+        (error: unknown) => {
+          // Treat a missing IAM role as success: the desired post-condition
+          // (role no longer exists) already holds. Without this branch an
+          // orphaned DB record (where the IAM role was deleted out-of-band)
+          // can never be cleaned up via the normal deleteResource path, which
+          // then blocks subsequent createResource calls with the duplicate-PK
+          // legacy guard.
+          const name = (error as { name?: string } | undefined)?.name;
+          if (name === "NoSuchEntity" || name === "NoSuchEntityException") {
+            logger.info(`IAM role ${input.iamRoleName} already absent; treating delete as success`);
+            return { ok: true as const };
+          }
+          throw error;
+        }
+      ),
+      (error) => {
+        const errorMessage = `Failed to delete role: ${error}`;
+        logger.error(errorMessage);
+        return new HandlerError(errorMessage, "INTERNAL_SERVER_ERROR");
+      }
+    ).map(() => input);
   };
 
 export type ListGitHubIamRoleAuditItemInAws = (input: ListGitHubIamRoleAuditItemCommand) => ResultAsync<ListGitHubIamRoleAuditItem, HandlerError>;

--- a/catalogs/iam-role/src/events/resource/gitHubIamRole.unit.test.ts
+++ b/catalogs/iam-role/src/events/resource/gitHubIamRole.unit.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { IamRoleCatalogConfig } from "../../config";
+import { createGitHubIamRoleName } from "./gitHubIamRole";
+
+const baseConfig: IamRoleCatalogConfig = IamRoleCatalogConfig.parse({
+  region: "us-west-2",
+  iamRoleFactoryAccountId: "123456789012",
+  iamRoleFactoryAccountRoleArn: "arn:aws:iam::123456789012:role/factory",
+  gitHubOrgNames: ["org-a", "org-b"],
+  policyNamePrefix: "stamp",
+  roleNamePrefix: "stamp",
+  awsAccountResourceTableName: "t-aws",
+  targetIamRoleResourceTableName: "t-target",
+  gitHubIamRoleResourceTableName: "t-github",
+  jumpIamRoleResourceTableName: "t-jump",
+});
+
+describe("createGitHubIamRoleName (multi-org)", () => {
+  it("creates the role name using the requested allowed org", () => {
+    const result = createGitHubIamRoleName(baseConfig)({ repositoryName: "my-repo", gitHubOrgName: "org-b" });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({
+        repositoryName: "my-repo",
+        gitHubOrgName: "org-b",
+        iamRoleName: "stamp-github-org-b-my-repo",
+      });
+    }
+  });
+
+  it("rejects an org that is not on the allow-list", () => {
+    const result = createGitHubIamRoleName(baseConfig)({ repositoryName: "my-repo", gitHubOrgName: "not-allowed" });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.userMessage).toContain("not allowed");
+      expect(result.error.userMessage).toContain("org-a");
+      expect(result.error.userMessage).toContain("org-b");
+    }
+  });
+
+  it("rejects when the resulting role name would exceed 64 characters", () => {
+    const result = createGitHubIamRoleName(baseConfig)({ repositoryName: "r".repeat(60), gitHubOrgName: "org-a" });
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/catalogs/iam-role/src/events/resource/gitHubIamRole.unit.test.ts
+++ b/catalogs/iam-role/src/events/resource/gitHubIamRole.unit.test.ts
@@ -42,4 +42,17 @@ describe("createGitHubIamRoleName (multi-org)", () => {
     const result = createGitHubIamRoleName(baseConfig)({ repositoryName: "r".repeat(60), gitHubOrgName: "org-a" });
     expect(result.isErr()).toBe(true);
   });
+
+  it("rejects empty repositoryName via runtime schema validation", () => {
+    const result = createGitHubIamRoleName(baseConfig)({ repositoryName: "", gitHubOrgName: "org-a" });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.userMessage).toContain("Failed to parse input");
+    }
+  });
+
+  it("rejects empty gitHubOrgName via runtime schema validation", () => {
+    const result = createGitHubIamRoleName(baseConfig)({ repositoryName: "my-repo", gitHubOrgName: "" });
+    expect(result.isErr()).toBe(true);
+  });
 });

--- a/catalogs/iam-role/src/events/resource/jumpIamRole.test.ts
+++ b/catalogs/iam-role/src/events/resource/jumpIamRole.test.ts
@@ -22,7 +22,7 @@ const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: "test-arn",
-  gitHubOrgName: githubOrgName,
+  gitHubOrgNames: [githubOrgName],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   awsAccountResourceTableName: `${process.env.IAM_ROLE_DYNAMO_TABLE_PREFIX}-iam-role-AWSAccountResource`,
@@ -202,7 +202,7 @@ describe("Testing jumpIamRole", () => {
       expect(result.value).toEqual(expected);
     });
 
-    it("returns failed result if Jump iam role name is invalid", async () => {
+    it("returns ok when the IAM role for an invalid Jump iam role name does not exist (idempotent)", async () => {
       const iamClient = new IAMClient({ region: "us-west-2" });
       const input: JumpIamRole = {
         jumpIamRoleName: "",
@@ -213,7 +213,7 @@ describe("Testing jumpIamRole", () => {
       };
       const resultAsync = deleteJumpIamRoleInAws(logger, iamClient)(input);
       const result = await resultAsync;
-      expect(result.isErr()).toBe(true);
+      expect(result.isOk()).toBe(true);
     });
 
     it("returns failed result if iam role name is invalid", async () => {
@@ -230,7 +230,7 @@ describe("Testing jumpIamRole", () => {
       expect(result.isErr()).toBe(true);
     });
 
-    it("returns failed result if iam role arn is invalid", async () => {
+    it("returns ok when the IAM role for an invalid iam role arn does not exist (idempotent)", async () => {
       const iamClient = new IAMClient({ region: "us-west-2" });
       const input: JumpIamRole = {
         jumpIamRoleName: "jumpTestServiceRole",
@@ -241,10 +241,10 @@ describe("Testing jumpIamRole", () => {
       };
       const resultAsync = deleteJumpIamRoleInAws(logger, iamClient)(input);
       const result = await resultAsync;
-      expect(result.isErr()).toBe(true);
+      expect(result.isOk()).toBe(true);
     });
 
-    it("returns failed result if created date is invalid", async () => {
+    it("returns ok when the IAM role for an invalid created date does not exist (idempotent)", async () => {
       const iamClient = new IAMClient({ region: "us-west-2" });
       const input: JumpIamRole = {
         jumpIamRoleName: "jumpTestServiceRole",
@@ -255,7 +255,7 @@ describe("Testing jumpIamRole", () => {
       };
       const resultAsync = deleteJumpIamRoleInAws(logger, iamClient)(input);
       const result = await resultAsync;
-      expect(result.isErr()).toBe(true);
+      expect(result.isOk()).toBe(true);
     });
   });
 });

--- a/catalogs/iam-role/src/events/resource/jumpIamRole.ts
+++ b/catalogs/iam-role/src/events/resource/jumpIamRole.ts
@@ -90,11 +90,28 @@ export const deleteJumpIamRoleInAws =
       RoleName: input.iamRoleName,
     });
 
-    return ResultAsync.fromPromise(iamClient.send(deleteRole), (error) => {
-      const errorMessage = `Failed to delete role: ${error}`;
-      logger.error(errorMessage);
-      return new HandlerError(errorMessage, "INTERNAL_SERVER_ERROR");
-    }).map(() => input);
+    return ResultAsync.fromPromise(
+      iamClient.send(deleteRole).then(
+        () => ({ ok: true as const }),
+        (error: unknown) => {
+          // Treat a missing IAM role as success — see the matching comment
+          // in `deleteGitHubIamRoleInAws`. Without this, orphaned DB
+          // records can never be cleaned up via the normal deleteResource
+          // path and block subsequent createResource calls.
+          const name = (error as { name?: string } | undefined)?.name;
+          if (name === "NoSuchEntity" || name === "NoSuchEntityException") {
+            logger.info(`IAM role ${input.iamRoleName} already absent; treating delete as success`);
+            return { ok: true as const };
+          }
+          throw error;
+        }
+      ),
+      (error) => {
+        const errorMessage = `Failed to delete role: ${error}`;
+        logger.error(errorMessage);
+        return new HandlerError(errorMessage, "INTERNAL_SERVER_ERROR");
+      }
+    ).map(() => input);
   };
 
 export type ListJumpIamRoleAuditItemInAws = (input: ListJumpIamRoleAuditItemCommand) => ResultAsync<ListJumpIamRoleAuditItem, HandlerError>;

--- a/catalogs/iam-role/src/events/resource/targetIamRole.test.ts
+++ b/catalogs/iam-role/src/events/resource/targetIamRole.test.ts
@@ -102,7 +102,7 @@ describe("Testing targetIamRole", () => {
       expect(result.value).toEqual(expected);
     });
 
-    it("returns failed result if account ID is invalid", async () => {
+    it("returns ok when the IAM policy for an invalid account ID does not exist (idempotent)", async () => {
       const iamClient: IAMClient = new IAMClient({ region: "us-west-2" });
       const input: TargetIamRole = {
         accountId: "",
@@ -113,10 +113,10 @@ describe("Testing targetIamRole", () => {
       };
       const resultAsync = deleteTargetIamRole(deleteAssumeRolePolicy(logger, iamClient))(input);
       const result = await resultAsync;
-      expect(result.isErr()).toBe(true);
+      expect(result.isOk()).toBe(true);
     });
 
-    it("returns failed result if iam role name is invalid", async () => {
+    it("returns ok when the IAM policy for an invalid iam role name does not exist (idempotent)", async () => {
       const iamClient: IAMClient = new IAMClient({ region: "us-west-2" });
       const input: TargetIamRole = {
         accountId: accountId,
@@ -127,10 +127,10 @@ describe("Testing targetIamRole", () => {
       };
       const resultAsync = deleteTargetIamRole(deleteAssumeRolePolicy(logger, iamClient))(input);
       const result = await resultAsync;
-      expect(result.isErr()).toBe(true);
+      expect(result.isOk()).toBe(true);
     });
 
-    it("returns failed result if ID is invalid", async () => {
+    it("returns ok when the IAM policy for an invalid ID does not exist (idempotent)", async () => {
       const iamClient: IAMClient = new IAMClient({ region: "us-west-2" });
       const input: TargetIamRole = {
         accountId: accountId,
@@ -141,7 +141,7 @@ describe("Testing targetIamRole", () => {
       };
       const resultAsync = deleteTargetIamRole(deleteAssumeRolePolicy(logger, iamClient))(input);
       const result = await resultAsync;
-      expect(result.isErr()).toBe(true);
+      expect(result.isOk()).toBe(true);
     });
 
     it("returns failed result if created date is invalid", async () => {

--- a/catalogs/iam-role/src/handlers/awsAccountResource.test.ts
+++ b/catalogs/iam-role/src/handlers/awsAccountResource.test.ts
@@ -21,7 +21,7 @@ const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: `arn:aws:iam::${iamRoleFactoryAccountId}:role/stamp-execute-role`,
-  gitHubOrgName: githubOrgName,
+  gitHubOrgNames: [githubOrgName],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   awsAccountResourceTableName: `${process.env.IAM_ROLE_DYNAMO_TABLE_PREFIX}-iam-role-AWSAccountResource`,

--- a/catalogs/iam-role/src/handlers/awsAccountResource.ts
+++ b/catalogs/iam-role/src/handlers/awsAccountResource.ts
@@ -259,7 +259,18 @@ const listRepositories = (
         }
 
         const item = result.value;
-        return okAsync({ roleName: input.iamRoleName, value: item.repositoryName, isJumpIamRole: false });
+        return okAsync({
+          roleName: input.iamRoleName,
+          // The `IamRoleNameIndex` GSI is KEYS_ONLY so non-key attributes are
+          // not projected. Use the PK as the audit value: multi-org records
+          // expose the full `${org}/${repo}` (so identically named repos under
+          // different orgs remain distinguishable in audit reports — collapsing
+          // them via `extractBareRepositoryName` would be a security-relevant
+          // misrepresentation). Legacy records have the bare repo name as the
+          // PK, so they continue to display as before.
+          value: item.repositoryName,
+          isJumpIamRole: false,
+        });
       });
     });
   });

--- a/catalogs/iam-role/src/handlers/gitHubIamRoleResource.test.ts
+++ b/catalogs/iam-role/src/handlers/gitHubIamRoleResource.test.ts
@@ -15,12 +15,13 @@ const iamRoleFactoryAccountId = process.env.IAM_ROLE_FACTORY_AWS_ACCOUNT_ID!;
 const resourceTypeId = "iam-role-aws-account";
 const repositoryName = "test-repository";
 const githubOrgName = process.env.GITHUB_ORG_NAME!;
+const repositoryResourceId = `${githubOrgName}/${repositoryName}`;
 
 const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: `arn:aws:iam::${iamRoleFactoryAccountId}:role/stamp-execute-role`,
-  gitHubOrgName: githubOrgName,
+  gitHubOrgNames: [githubOrgName],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   gitHubIamRoleResourceTableName: `${process.env.IAM_ROLE_DYNAMO_TABLE_PREFIX}-iam-role-GitHubIamRoleResource`,
@@ -35,7 +36,7 @@ describe("Testing gitHubIamRoleResource", () => {
   beforeAll(async () => {
     const input: DeleteResourceInput = {
       resourceTypeId: resourceTypeId,
-      resourceId: repositoryName,
+      resourceId: repositoryResourceId,
     };
     await gitHubIamRoleResource.deleteResource(input);
   });
@@ -43,7 +44,7 @@ describe("Testing gitHubIamRoleResource", () => {
   afterAll(async () => {
     const input: DeleteResourceInput = {
       resourceTypeId: resourceTypeId,
-      resourceId: repositoryName,
+      resourceId: repositoryResourceId,
     };
     await gitHubIamRoleResource.deleteResource(input);
   });
@@ -54,15 +55,17 @@ describe("Testing gitHubIamRoleResource", () => {
         resourceTypeId: resourceTypeId,
         inputParams: {
           repositoryName: repositoryName,
+          gitHubOrgName: githubOrgName,
         },
       };
       const expected: ResourceOutput = {
         params: {
           repositoryName: repositoryName,
+          gitHubOrgName: githubOrgName,
           iamRoleArn: expect.any(String),
         },
-        name: repositoryName,
-        resourceId: repositoryName,
+        name: repositoryResourceId,
+        resourceId: repositoryResourceId,
       };
       const result = await gitHubIamRoleResource.createResource(input);
       if (result.isErr()) {
@@ -82,6 +85,7 @@ describe("Testing gitHubIamRoleResource", () => {
         resourceTypeId: resourceTypeId,
         inputParams: {
           repositoryName: "",
+          gitHubOrgName: githubOrgName,
         },
       };
       const result = await gitHubIamRoleResource.createResource(input);
@@ -93,6 +97,7 @@ describe("Testing gitHubIamRoleResource", () => {
         resourceTypeId: resourceTypeId,
         inputParams: {
           repositoryName: 100,
+          gitHubOrgName: githubOrgName,
         },
       };
       const resultAsync = gitHubIamRoleResource.createResource(input);
@@ -105,15 +110,16 @@ describe("Testing gitHubIamRoleResource", () => {
     it("returns successful result", async () => {
       const input: GetResourceInput = {
         resourceTypeId: resourceTypeId,
-        resourceId: repositoryName,
+        resourceId: repositoryResourceId,
       };
       const expected: ResourceOutput = {
         params: {
           repositoryName: repositoryName,
+          gitHubOrgName: githubOrgName,
           iamRoleArn: expect.any(String),
         },
-        name: repositoryName,
-        resourceId: repositoryName,
+        name: repositoryResourceId,
+        resourceId: repositoryResourceId,
       };
       const result = await gitHubIamRoleResource.getResource(input);
       if (result.isErr()) {
@@ -167,7 +173,7 @@ describe("Testing gitHubIamRoleResource", () => {
     it("returns successful result", async () => {
       const input: ListResourceAuditItemInput = {
         resourceTypeId: resourceTypeId,
-        resourceId: repositoryName,
+        resourceId: repositoryResourceId,
       };
       const result = await gitHubIamRoleResource.listResourceAuditItem(input);
       if (result.isErr()) {
@@ -199,7 +205,7 @@ describe("Testing gitHubIamRoleResource", () => {
     it("returns successful result", async () => {
       const input: DeleteResourceInput = {
         resourceTypeId: resourceTypeId,
-        resourceId: repositoryName,
+        resourceId: repositoryResourceId,
       };
       const result = await gitHubIamRoleResource.deleteResource(input);
       expect(result.isOk()).toBe(true);

--- a/catalogs/iam-role/src/handlers/gitHubIamRoleResource.ts
+++ b/catalogs/iam-role/src/handlers/gitHubIamRoleResource.ts
@@ -121,11 +121,13 @@ const createResourceHandler =
     // Also guard against a legacy single-org record stored under the bare
     // repository name as PK. Such a record would otherwise be invisible to the
     // compound-PK lookup above and we would proceed to call IAM CreateRole
-    // with a name that already exists. This check is only meaningful when the
-    // requested org is the first allow-listed org (which is what legacy
-    // records implicitly belong to per `resolveDisplayFields`).
-    const legacyOrgName = parsedConfig.gitHubOrgNames[0];
-    if (gitHubOrgName === legacyOrgName && repositoryName !== pkValue) {
+    // with a name that already exists. Always look up the bare-PK item (not
+    // just when the requested org happens to be first in the allowlist) and
+    // reject only when its stored `iamRoleName` matches what we are about to
+    // create — this makes the check independent of allowlist ordering and
+    // avoids returning a clean `BAD_REQUEST` for an unrelated legacy record
+    // that targets a different org.
+    if (repositoryName !== pkValue) {
       const legacyResult = await getGitHubIamRoleDBItem(logger, parsedConfig.gitHubIamRoleResourceTableName, { region: parsedConfig.region })({
         repositoryName: repositoryName,
       });
@@ -133,8 +135,11 @@ const createResourceHandler =
         return err(new HandlerError(`${legacyResult.error}`, "INTERNAL_SERVER_ERROR"));
       }
       if (legacyResult.isOk() && legacyResult.value.isSome()) {
-        const message = `The GitHub IAM role for ${gitHubOrgName}/${repositoryName} already exists (legacy record).`;
-        return err(new HandlerError(message, "BAD_REQUEST", message));
+        const prospectiveIamRoleName = `${parsedConfig.roleNamePrefix}-github-${gitHubOrgName}-${repositoryName}`;
+        if (legacyResult.value.value.iamRoleName === prospectiveIamRoleName) {
+          const message = `The GitHub IAM role for ${gitHubOrgName}/${repositoryName} already exists (legacy record).`;
+          return err(new HandlerError(message, "BAD_REQUEST", message));
+        }
       }
     }
 

--- a/catalogs/iam-role/src/handlers/gitHubIamRoleResource.ts
+++ b/catalogs/iam-role/src/handlers/gitHubIamRoleResource.ts
@@ -15,10 +15,59 @@ import { createLogger } from "@stamp-lib/stamp-logger";
 import { some, Option, none } from "@stamp-lib/stamp-option";
 import { IAMClient } from "@aws-sdk/client-iam";
 import { IamRoleCatalogConfig } from "../config";
-import { getGitHubIamRoleDBItem, listGitHubIamRoleDBItem, createGitHubIamRoleDBItem, deleteGitHubIamRoleDBItem } from "../events/database/gitHubIamRoleDB";
+import {
+  buildGitHubIamRolePkValue,
+  getGitHubIamRoleDBItem,
+  listGitHubIamRoleDBItem,
+  createGitHubIamRoleDBItem,
+  deleteGitHubIamRoleDBItem,
+} from "../events/database/gitHubIamRoleDB";
 import { createGitHubIamRoleInAws, createGitHubIamRoleName, deleteGitHubIamRoleInAws, listGitHubIamRoleAuditItemInAws } from "../events/resource/gitHubIamRole";
 import { listIamRoleAttachedPolicyArns, fetchAllAttachedRolePolicyArns } from "../events/iam-ops/iamRoleManagement";
 import { assumeRoleCredentialProvider } from "../utils/assumeRoleCredentialProvider";
+import { GitHubIamRole } from "../types/gitHubIamRole";
+
+/**
+ * Resolves the user-facing repository name and GitHub organization for a
+ * persisted GitHub IAM Role record. For records created before multi-org
+ * support the new attributes are absent; the bare PK *is* the repository
+ * name so that fallback is exact, but the org cannot be safely inferred
+ * (a wrong attribution could mislead operators), so it is returned as
+ * `undefined` and downstream callers must handle the missing value
+ * explicitly.
+ */
+export const resolveDisplayFields = (
+  item: GitHubIamRole,
+  _config: IamRoleCatalogConfig
+): { repositoryName: string; gitHubOrgName: string | undefined; isLegacy: boolean } => {
+  const isLegacy = !item.gitHubOrgName;
+  return {
+    repositoryName: item.gitHubRepositoryName ?? item.repositoryName,
+    gitHubOrgName: item.gitHubOrgName,
+    isLegacy,
+  };
+};
+
+export const buildResourceOutput = (item: GitHubIamRole, config: IamRoleCatalogConfig): ResourceOutput => {
+  const display = resolveDisplayFields(item, config);
+  // For multi-org records, the user-visible name encodes the org so identically
+  // named repositories under different orgs remain distinguishable in selector
+  // UIs that key off `resource.name`. Legacy single-org records keep the bare
+  // repository name to avoid changing how existing resources are displayed.
+  const displayName = display.isLegacy || !display.gitHubOrgName ? display.repositoryName : `${display.gitHubOrgName}/${display.repositoryName}`;
+  const params: Record<string, string> = {
+    repositoryName: display.repositoryName,
+    iamRoleArn: item.iamRoleArn,
+  };
+  if (display.gitHubOrgName) {
+    params.gitHubOrgName = display.gitHubOrgName;
+  }
+  return {
+    resourceId: item.repositoryName,
+    name: displayName,
+    params,
+  };
+};
 
 export function createGitHubIamRoleResourceHandler(iamRoleCatalogConfig: IamRoleCatalogConfig): ResourceHandlers {
   const gitHubIamRoleResourceHandler: ResourceHandlers = {
@@ -45,42 +94,64 @@ const createResourceHandler =
     if (typeof input.inputParams.repositoryName !== "string" || input.inputParams.repositoryName.trim() === "") {
       return err(new HandlerError("Invalid input parameters(repositoryName)", "BAD_REQUEST", "Invalid input parameters(repositoryName)"));
     }
+    if (typeof input.inputParams.gitHubOrgName !== "string" || input.inputParams.gitHubOrgName.trim() === "") {
+      return err(new HandlerError("Invalid input parameters(gitHubOrgName)", "BAD_REQUEST", "Invalid input parameters(gitHubOrgName)"));
+    }
+    if (!parsedConfig.gitHubOrgNames.includes(input.inputParams.gitHubOrgName)) {
+      const message = `GitHub organization "${input.inputParams.gitHubOrgName}" is not allowed. Allowed organizations: ${parsedConfig.gitHubOrgNames.join(", ")}.`;
+      return err(new HandlerError(message, "BAD_REQUEST", message));
+    }
+
+    const repositoryName = input.inputParams.repositoryName;
+    const gitHubOrgName = input.inputParams.gitHubOrgName;
+    const pkValue = buildGitHubIamRolePkValue(gitHubOrgName, repositoryName);
 
     // If it has already been created, an error indicating "already created" will be returned.
-    const result = await getGitHubIamRoleDBItem(logger, iamRoleCatalogConfig.gitHubIamRoleResourceTableName, { region: iamRoleCatalogConfig.region })({
-      repositoryName: input.inputParams.repositoryName,
+    const result = await getGitHubIamRoleDBItem(logger, parsedConfig.gitHubIamRoleResourceTableName, { region: parsedConfig.region })({
+      repositoryName: pkValue,
     });
     if (result.isErr()) {
       return err(new HandlerError(`${result.error}`, "INTERNAL_SERVER_ERROR"));
     }
     if (result.isOk() && result.value.isSome()) {
-      const gitHubIamRole = result.value.unwrapOr();
-      const message = `The GitHub IAM role for ${gitHubIamRole.repositoryName} already exists.`;
+      const message = `The GitHub IAM role for ${gitHubOrgName}/${repositoryName} already exists.`;
       return err(new HandlerError(message, "BAD_REQUEST", message));
     }
 
+    // Also guard against a legacy single-org record stored under the bare
+    // repository name as PK. Such a record would otherwise be invisible to the
+    // compound-PK lookup above and we would proceed to call IAM CreateRole
+    // with a name that already exists. This check is only meaningful when the
+    // requested org is the first allow-listed org (which is what legacy
+    // records implicitly belong to per `resolveDisplayFields`).
+    const legacyOrgName = parsedConfig.gitHubOrgNames[0];
+    if (gitHubOrgName === legacyOrgName && repositoryName !== pkValue) {
+      const legacyResult = await getGitHubIamRoleDBItem(logger, parsedConfig.gitHubIamRoleResourceTableName, { region: parsedConfig.region })({
+        repositoryName: repositoryName,
+      });
+      if (legacyResult.isErr()) {
+        return err(new HandlerError(`${legacyResult.error}`, "INTERNAL_SERVER_ERROR"));
+      }
+      if (legacyResult.isOk() && legacyResult.value.isSome()) {
+        const message = `The GitHub IAM role for ${gitHubOrgName}/${repositoryName} already exists (legacy record).`;
+        return err(new HandlerError(message, "BAD_REQUEST", message));
+      }
+    }
+
     const createInput = {
-      repositoryName: input.inputParams.repositoryName,
+      repositoryName,
+      gitHubOrgName,
     };
 
     const iamClient = new IAMClient({
-      region: iamRoleCatalogConfig.region,
-      credentials: assumeRoleCredentialProvider(iamRoleCatalogConfig.iamRoleFactoryAccountRoleArn, iamRoleCatalogConfig.region),
+      region: parsedConfig.region,
+      credentials: assumeRoleCredentialProvider(parsedConfig.iamRoleFactoryAccountRoleArn, parsedConfig.region),
     });
 
-    return await createGitHubIamRoleName(iamRoleCatalogConfig)(createInput)
-      .asyncAndThen(createGitHubIamRoleInAws(logger, iamRoleCatalogConfig, iamClient))
-      .andThen(createGitHubIamRoleDBItem(logger, iamRoleCatalogConfig.gitHubIamRoleResourceTableName, { region: iamRoleCatalogConfig.region }))
-      .map((result) => {
-        return {
-          resourceId: result.repositoryName,
-          name: result.repositoryName,
-          params: {
-            repositoryName: result.repositoryName,
-            iamRoleArn: result.iamRoleArn,
-          },
-        };
-      });
+    return await createGitHubIamRoleName(parsedConfig)(createInput)
+      .asyncAndThen(createGitHubIamRoleInAws(logger, parsedConfig, iamClient))
+      .andThen(createGitHubIamRoleDBItem(logger, parsedConfig.gitHubIamRoleResourceTableName, { region: parsedConfig.region }))
+      .map((persisted) => buildResourceOutput(persisted, parsedConfig));
   };
 
 const deleteResourceHandler =
@@ -94,11 +165,11 @@ const deleteResourceHandler =
       repositoryName: input.resourceId,
     };
     const iamClient = new IAMClient({
-      region: iamRoleCatalogConfig.region,
-      credentials: assumeRoleCredentialProvider(iamRoleCatalogConfig.iamRoleFactoryAccountRoleArn, iamRoleCatalogConfig.region),
+      region: parsedConfig.region,
+      credentials: assumeRoleCredentialProvider(parsedConfig.iamRoleFactoryAccountRoleArn, parsedConfig.region),
     });
 
-    return await getGitHubIamRoleDBItem(logger, iamRoleCatalogConfig.gitHubIamRoleResourceTableName, { region: iamRoleCatalogConfig.region })(deleteInput)
+    return await getGitHubIamRoleDBItem(logger, parsedConfig.gitHubIamRoleResourceTableName, { region: parsedConfig.region })(deleteInput)
       .andThen((result) => {
         if (result.isNone()) {
           const message = `Resource ${input.resourceId} Not exist`;
@@ -108,7 +179,7 @@ const deleteResourceHandler =
         }
       })
       .andThen(deleteGitHubIamRoleInAws(logger, iamClient))
-      .andThen(deleteGitHubIamRoleDBItem(logger, iamRoleCatalogConfig.gitHubIamRoleResourceTableName, { region: iamRoleCatalogConfig.region }))
+      .andThen(() => deleteGitHubIamRoleDBItem(logger, parsedConfig.gitHubIamRoleResourceTableName, { region: parsedConfig.region })(deleteInput))
       .map(() => {});
   };
 
@@ -123,22 +194,13 @@ const getResourceHandler =
       repositoryName: input.resourceId,
     };
 
-    return await getGitHubIamRoleDBItem(logger, iamRoleCatalogConfig.gitHubIamRoleResourceTableName, { region: iamRoleCatalogConfig.region })(getInput).map(
-      (result) => {
-        if (result.isNone()) {
-          return none;
-        } else {
-          return some({
-            resourceId: result.value.repositoryName,
-            name: result.value.repositoryName,
-            params: {
-              repositoryName: result.value.repositoryName,
-              iamRoleArn: result.value.iamRoleArn,
-            },
-          });
-        }
+    return await getGitHubIamRoleDBItem(logger, parsedConfig.gitHubIamRoleResourceTableName, { region: parsedConfig.region })(getInput).map((result) => {
+      if (result.isNone()) {
+        return none;
+      } else {
+        return some(buildResourceOutput(result.value, parsedConfig));
       }
-    );
+    });
   };
 
 const listResourcesHandler =
@@ -153,23 +215,12 @@ const listResourcesHandler =
       nextToken: input.paginationToken,
     };
 
-    return await listGitHubIamRoleDBItem(logger, iamRoleCatalogConfig.gitHubIamRoleResourceTableName, { region: iamRoleCatalogConfig.region })(listInput).map(
-      (result) => {
-        return {
-          resources: result.items.map((item) => {
-            return {
-              resourceId: item.repositoryName,
-              name: item.repositoryName,
-              params: {
-                repositoryName: item.repositoryName,
-                iamRoleArn: item.iamRoleArn,
-              },
-            };
-          }),
-          nextToken: result.nextToken,
-        };
-      }
-    );
+    return await listGitHubIamRoleDBItem(logger, parsedConfig.gitHubIamRoleResourceTableName, { region: parsedConfig.region })(listInput).map((result) => {
+      return {
+        resources: result.items.map((item) => buildResourceOutput(item, parsedConfig)),
+        nextToken: result.nextToken,
+      };
+    });
   };
 
 const listResourceAuditItemHandler =
@@ -183,11 +234,11 @@ const listResourceAuditItemHandler =
       repositoryName: input.resourceId,
     };
     const iamClient = new IAMClient({
-      region: iamRoleCatalogConfig.region,
-      credentials: assumeRoleCredentialProvider(iamRoleCatalogConfig.iamRoleFactoryAccountRoleArn, iamRoleCatalogConfig.region),
+      region: parsedConfig.region,
+      credentials: assumeRoleCredentialProvider(parsedConfig.iamRoleFactoryAccountRoleArn, parsedConfig.region),
     });
 
-    return getGitHubIamRoleDBItem(logger, iamRoleCatalogConfig.gitHubIamRoleResourceTableName, { region: iamRoleCatalogConfig.region })(getInput)
+    return getGitHubIamRoleDBItem(logger, parsedConfig.gitHubIamRoleResourceTableName, { region: parsedConfig.region })(getInput)
       .andThen((result) => {
         if (result.isNone()) {
           const message = `Resource ${input.resourceId} does not exist`;

--- a/catalogs/iam-role/src/handlers/gitHubIamRoleResource.unit.test.ts
+++ b/catalogs/iam-role/src/handlers/gitHubIamRoleResource.unit.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { IamRoleCatalogConfig } from "../config";
+import { buildResourceOutput, resolveDisplayFields } from "./gitHubIamRoleResource";
+
+const makeConfig = (overrides: Partial<Record<string, unknown>> = {}): IamRoleCatalogConfig =>
+  IamRoleCatalogConfig.parse({
+    region: "us-west-2",
+    iamRoleFactoryAccountId: "123456789012",
+    iamRoleFactoryAccountRoleArn: "arn:aws:iam::123456789012:role/factory",
+    gitHubOrgNames: ["org-a", "org-b"],
+    policyNamePrefix: "stamp",
+    roleNamePrefix: "stamp",
+    awsAccountResourceTableName: "t-aws",
+    targetIamRoleResourceTableName: "t-target",
+    gitHubIamRoleResourceTableName: "t-github",
+    jumpIamRoleResourceTableName: "t-jump",
+    ...overrides,
+  });
+
+describe("resolveDisplayFields / buildResourceOutput", () => {
+  it("legacy record (no gitHubOrgName attribute) returns undefined org (no silent fallback)", () => {
+    const cfg = makeConfig({ gitHubOrgNames: ["org-b", "org-a"] });
+    const display = resolveDisplayFields(
+      { repositoryName: "old-repo", iamRoleName: "x", iamRoleArn: "y", createdAt: "2024-01-01" },
+      cfg
+    );
+    expect(display).toEqual({ repositoryName: "old-repo", gitHubOrgName: undefined, isLegacy: true });
+  });
+
+  it("legacy record exposes bare repo name from the PK without guessing the org", () => {
+    const cfg = makeConfig({ gitHubOrgNames: ["org-a", "org-b"] });
+    const display = resolveDisplayFields(
+      { repositoryName: "old-repo", iamRoleName: "x", iamRoleArn: "y", createdAt: "2024-01-01" },
+      cfg
+    );
+    expect(display.gitHubOrgName).toBeUndefined();
+    expect(display.repositoryName).toBe("old-repo");
+    expect(display.isLegacy).toBe(true);
+  });
+
+  it("compound record exposes bare repo name and explicit org", () => {
+    const cfg = makeConfig();
+    const display = resolveDisplayFields(
+      {
+        repositoryName: "org-b/new-repo",
+        gitHubRepositoryName: "new-repo",
+        gitHubOrgName: "org-b",
+        iamRoleName: "x",
+        iamRoleArn: "y",
+        createdAt: "2024-01-01",
+      },
+      cfg
+    );
+    expect(display).toEqual({ repositoryName: "new-repo", gitHubOrgName: "org-b", isLegacy: false });
+  });
+
+  it("buildResourceOutput keeps bare display name for legacy records and omits gitHubOrgName from params", () => {
+    const cfg = makeConfig({ gitHubOrgNames: ["org-a"] });
+    const output = buildResourceOutput(
+      { repositoryName: "legacy-repo", iamRoleName: "r", iamRoleArn: "arn", createdAt: "2024-01-01" },
+      cfg
+    );
+    expect(output.resourceId).toBe("legacy-repo");
+    expect(output.name).toBe("legacy-repo");
+    expect(output.params).toEqual({
+      repositoryName: "legacy-repo",
+      iamRoleArn: "arn",
+    });
+    expect(output.params.gitHubOrgName).toBeUndefined();
+  });
+
+  it("buildResourceOutput uses compound display name for multi-org records (so same repo name across orgs is distinguishable in UI)", () => {
+    const cfg = makeConfig();
+    const output = buildResourceOutput(
+      {
+        repositoryName: "org-b/shared-repo",
+        gitHubRepositoryName: "shared-repo",
+        gitHubOrgName: "org-b",
+        iamRoleName: "r",
+        iamRoleArn: "arn",
+        createdAt: "2024-01-01",
+      },
+      cfg
+    );
+    expect(output.resourceId).toBe("org-b/shared-repo");
+    expect(output.name).toBe("org-b/shared-repo");
+    expect(output.params).toEqual({
+      repositoryName: "shared-repo",
+      gitHubOrgName: "org-b",
+      iamRoleArn: "arn",
+    });
+  });
+});

--- a/catalogs/iam-role/src/handlers/iamRolePromoteRequest.policyGrantLimitScenario.test.ts
+++ b/catalogs/iam-role/src/handlers/iamRolePromoteRequest.policyGrantLimitScenario.test.ts
@@ -21,12 +21,14 @@ const tableNameForJumpIamRole = `${process.env.IAM_ROLE_DYNAMO_TABLE_PREFIX}-iam
 
 const iamRoleFactoryAccountId = process.env.IAM_ROLE_FACTORY_AWS_ACCOUNT_ID!;
 const githubOrgName = process.env.GITHUB_ORG_NAME!;
+const repositoryName = "stamp-testRepository-promote";
+const repositoryResourceId = `${githubOrgName}/${repositoryName}`;
 
 const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: `arn:aws:iam::${iamRoleFactoryAccountId}:role/stamp-execute-role`,
-  gitHubOrgName: githubOrgName,
+  gitHubOrgNames: [githubOrgName],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   awsAccountResourceTableName: tableNameForAWSAccount,
@@ -49,7 +51,7 @@ function createApprovedValidationInput(suffix: number): ApprovalRequestValidatio
     },
     inputResources: {
       "github-iam-role": {
-        resourceId: "stamp-testRepository-promote",
+        resourceId: repositoryResourceId,
         resourceTypeId: "test-resource-type",
       },
       "aws-account": {
@@ -83,7 +85,7 @@ describe(
       });
       await gitHubIamRoleResourceHandler.deleteResource({
         resourceTypeId: "test-resource-type",
-        resourceId: "stamp-testRepository-promote",
+        resourceId: repositoryResourceId,
       });
       for (let suffix = 1; suffix <= 11; suffix++) {
         await targetIamRoleResourceHandler.deleteResource({
@@ -102,7 +104,8 @@ describe(
       await gitHubIamRoleResourceHandler.createResource({
         resourceTypeId: "test-resource-type",
         inputParams: {
-          repositoryName: "stamp-testRepository-promote",
+          repositoryName: repositoryName,
+          gitHubOrgName: githubOrgName,
         },
       });
       for (let suffix = 1; suffix <= 11; suffix++) {
@@ -168,7 +171,7 @@ describe(
       });
       await gitHubIamRoleResourceHandler.deleteResource({
         resourceTypeId: "test-resource-type",
-        resourceId: "stamp-testRepository-promote",
+        resourceId: repositoryResourceId,
       });
     }, 300000); // Set timeout to 300 seconds
 

--- a/catalogs/iam-role/src/handlers/iamRolePromoteRequest.test.ts
+++ b/catalogs/iam-role/src/handlers/iamRolePromoteRequest.test.ts
@@ -33,12 +33,13 @@ const revokedDate = "2023-11-01T10:00:00.000Z";
 
 const iamRoleFactoryAccountId = process.env.IAM_ROLE_FACTORY_AWS_ACCOUNT_ID!;
 const githubOrgName = process.env.GITHUB_ORG_NAME!;
+const repositoryResourceId = `${githubOrgName}/${repositoryName}`;
 
 const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: `arn:aws:iam::${iamRoleFactoryAccountId}:role/stamp-execute-role`,
-  gitHubOrgName: githubOrgName,
+  gitHubOrgNames: [githubOrgName],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   awsAccountResourceTableName: tableNameForAWSAccount,
@@ -60,7 +61,7 @@ const approvedInput: ApprovedInput = {
   },
   inputResources: {
     "github-iam-role": {
-      resourceId: repositoryName,
+      resourceId: repositoryResourceId,
       resourceTypeId: resourceTypeId,
     },
     "aws-account": {
@@ -99,7 +100,7 @@ describe("Testing iamRolePromoteRequest", () => {
     });
     await gitHubIamRoleResourceHandler.deleteResource({
       resourceTypeId: resourceTypeId,
-      resourceId: repositoryName,
+      resourceId: repositoryResourceId,
     });
     await targetIamRoleResourceHandler.deleteResource({
       resourceTypeId: resourceTypeId,
@@ -117,6 +118,7 @@ describe("Testing iamRolePromoteRequest", () => {
       resourceTypeId: resourceTypeId,
       inputParams: {
         repositoryName: repositoryName,
+        gitHubOrgName: githubOrgName,
       },
     });
     await targetIamRoleResourceHandler.createResource({
@@ -138,7 +140,7 @@ describe("Testing iamRolePromoteRequest", () => {
     });
     await gitHubIamRoleResourceHandler.deleteResource({
       resourceTypeId: resourceTypeId,
-      resourceId: repositoryName,
+      resourceId: repositoryResourceId,
     });
     await targetIamRoleResourceHandler.deleteResource({
       resourceTypeId: resourceTypeId,
@@ -168,7 +170,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...approvalRequestValidationInput,
           inputResources: {
             "": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "aws-account": {
@@ -188,7 +190,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...approvalRequestValidationInput,
           inputResources: {
             "github-iam-role": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "": {
@@ -208,7 +210,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...approvalRequestValidationInput,
           inputResources: {
             "github-iam-role": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "aws-account": {
@@ -248,7 +250,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...approvalRequestValidationInput,
           inputResources: {
             "github-iam-role": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "aws-account": {
@@ -268,7 +270,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...approvalRequestValidationInput,
           inputResources: {
             "github-iam-role": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "aws-account": {
@@ -315,7 +317,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...approvalRequestValidationInput,
           inputResources: {
             "github-iam-role": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "aws-account": {
@@ -335,7 +337,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...approvalRequestValidationInput,
           inputResources: {
             "github-iam-role": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "aws-account": {
@@ -385,7 +387,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...approvedInput,
           inputResources: {
             "": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "aws-account": {
@@ -405,7 +407,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...approvedInput,
           inputResources: {
             "github-iam-role": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "": {
@@ -425,7 +427,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...approvedInput,
           inputResources: {
             "github-iam-role": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "aws-account": {
@@ -472,7 +474,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...approvedInput,
           inputResources: {
             "github-iam-role": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "aws-account": {
@@ -492,7 +494,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...approvedInput,
           inputResources: {
             "github-iam-role": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "aws-account": {
@@ -532,7 +534,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...approvedInput,
           inputResources: {
             "github-iam-role": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "aws-account": {
@@ -552,7 +554,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...approvedInput,
           inputResources: {
             "github-iam-role": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "aws-account": {
@@ -602,7 +604,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...revokedInput,
           inputResources: {
             "": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "aws-account": {
@@ -622,7 +624,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...revokedInput,
           inputResources: {
             "github-iam-role": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "": {
@@ -642,7 +644,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...revokedInput,
           inputResources: {
             "github-iam-role": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "aws-account": {
@@ -689,7 +691,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...revokedInput,
           inputResources: {
             "github-iam-role": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "aws-account": {
@@ -709,7 +711,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...revokedInput,
           inputResources: {
             "github-iam-role": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "aws-account": {
@@ -749,7 +751,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...revokedInput,
           inputResources: {
             "github-iam-role": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "aws-account": {
@@ -769,7 +771,7 @@ describe("Testing iamRolePromoteRequest", () => {
           ...revokedInput,
           inputResources: {
             "github-iam-role": {
-              resourceId: repositoryName,
+              resourceId: repositoryResourceId,
               resourceTypeId: resourceTypeId,
             },
             "aws-account": {

--- a/catalogs/iam-role/src/handlers/jumpIamRolePromoteRequest.policyGrantLimitScenario.test.ts
+++ b/catalogs/iam-role/src/handlers/jumpIamRolePromoteRequest.policyGrantLimitScenario.test.ts
@@ -27,7 +27,7 @@ const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: `arn:aws:iam::${iamRoleFactoryAccountId}:role/stamp-execute-role`,
-  gitHubOrgName: githubOrgName,
+  gitHubOrgNames: [githubOrgName],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   awsAccountResourceTableName: tableNameForAWSAccount,

--- a/catalogs/iam-role/src/handlers/jumpIamRolePromoteRequest.test.ts
+++ b/catalogs/iam-role/src/handlers/jumpIamRolePromoteRequest.test.ts
@@ -39,7 +39,7 @@ const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: `arn:aws:iam::${iamRoleFactoryAccountId}:role/stamp-execute-role`,
-  gitHubOrgName: githubOrgName,
+  gitHubOrgNames: [githubOrgName],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   awsAccountResourceTableName: tableNameForAWSAccount,
@@ -124,7 +124,7 @@ describe("Testing iamRolePromoteRequest", () => {
     await targetIamRoleResourceHandler.createResource({
       resourceTypeId: resourceTypeId,
       inputParams: {
-        iamRoleName: "common-deployment-test",
+        iamRoleName: "deployment-test",
       },
       parentResourceId: accountId,
     });

--- a/catalogs/iam-role/src/handlers/jumpIamRoleResource.test.ts
+++ b/catalogs/iam-role/src/handlers/jumpIamRoleResource.test.ts
@@ -21,7 +21,7 @@ const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: `arn:aws:iam::${iamRoleFactoryAccountId}:role/stamp-execute-role`,
-  gitHubOrgName: githubOrgName,
+  gitHubOrgNames: [githubOrgName],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   gitHubIamRoleResourceTableName: `${process.env.IAM_ROLE_DYNAMO_TABLE_PREFIX}-iam-role-GitHubIamRoleResource`,

--- a/catalogs/iam-role/src/handlers/targetIamRoleResource.test.ts
+++ b/catalogs/iam-role/src/handlers/targetIamRoleResource.test.ts
@@ -23,7 +23,7 @@ const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: `arn:aws:iam::${iamRoleFactoryAccountId}:role/stamp-execute-role`,
-  gitHubOrgName: githubOrgName,
+  gitHubOrgNames: [githubOrgName],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   gitHubIamRoleResourceTableName: `${process.env.IAM_ROLE_DYNAMO_TABLE_PREFIX}-iam-role-GitHubIamRoleResource`,

--- a/catalogs/iam-role/src/handlers/targetIamRoleResource.ts
+++ b/catalogs/iam-role/src/handlers/targetIamRoleResource.ts
@@ -232,6 +232,11 @@ const listResourceAuditItemHandler =
             }
 
             const item = result.value;
+            // Use the PK as-is for audit display: multi-org records are
+            // `${org}/${repo}` and legacy records are the bare repo name.
+            // Stripping the org via `extractBareRepositoryName` would collapse
+            // identically named repos under different orgs into one audit
+            // entry, which would misrepresent which org has access.
             return okAsync(item.repositoryName);
           });
         });

--- a/catalogs/iam-role/src/index.ts
+++ b/catalogs/iam-role/src/index.ts
@@ -45,8 +45,12 @@ export function createIamRoleCatalog(iamRoleCatalogConfigInput: IamRoleCatalogCo
     id: "github-iam-role",
     name: "GitHub IAM Role",
     description: "GitHub IAM Role",
-    createParams: [{ type: "string", id: "repositoryName", name: "Repository Name", required: true }],
+    createParams: [
+      { type: "string", id: "gitHubOrgName", name: "GitHub Organization", required: true },
+      { type: "string", id: "repositoryName", name: "Repository Name", required: true },
+    ],
     infoParams: [
+      { type: "string", id: "gitHubOrgName", name: "GitHub Organization", edit: false },
       { type: "string", id: "repositoryName", name: "Repository Name", edit: false },
       { type: "string", id: "iamRoleArn", name: "IAM Role Arn", edit: false },
     ],

--- a/catalogs/iam-role/src/intergration-test/iamRolePromoteRequest.test.ts
+++ b/catalogs/iam-role/src/intergration-test/iamRolePromoteRequest.test.ts
@@ -2,6 +2,8 @@ import { ApprovedInput, ApprovedOutput, ListResourceAuditItemInput, RevokedInput
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { IamRoleCatalogConfig } from "../config";
 import { createAwsAccountDBItem, deleteAwsAccountDBItem } from "../events/database/awsAccountDB";
+import { listTargetIamRoleDBItemByAccountId } from "../events/database/targetIamRoleDB";
+import { listGitHubIamRoleDBItem } from "../events/database/gitHubIamRoleDB";
 import { createAwsAccountResourceHandler } from "../handlers/awsAccountResource";
 import { createGitHubIamRoleResourceHandler } from "../handlers/gitHubIamRoleResource";
 import { createIamRolePromoteRequestHandler } from "../handlers/iamRolePromoteRequest";
@@ -73,6 +75,35 @@ const revokedInput: RevokedInput = {
 describe("Testing iamRolePromoteRequest", () => {
   const logger = createLogger("DEBUG", { moduleName: "iam-role" });
   beforeAll(async () => {
+    // Aggressive orphan cleanup: list-and-delete all target-iam-role and
+    // github-iam-role records associated with the test account / orgs so a
+    // prior interrupted run does not leak entries into this run's assertions.
+    // The table names are scoped by `IAM_ROLE_DYNAMO_TABLE_PREFIX` (the
+    // `${prefix}-iam-role-*` test tables), so this only affects the test
+    // environment's tables — never production data.
+    const listTargetItems = await listTargetIamRoleDBItemByAccountId(logger, tableNameForTargetIamRole, { region: config.region })({
+      accountId: "222233334444",
+    });
+    if (listTargetItems.isOk()) {
+      for (const item of listTargetItems.value.items) {
+        await targetIamRoleResourceHandler.deleteResource({
+          resourceTypeId: "test-resource-type",
+          resourceId: item.id,
+        });
+      }
+    }
+    const listGitHubItems = await listGitHubIamRoleDBItem(logger, tableNameForGitHubIamRole, { region: config.region })({});
+    if (listGitHubItems.isOk()) {
+      for (const item of listGitHubItems.value.items) {
+        if (item.repositoryName === repositoryName || item.repositoryName === repositoryName2 || item.repositoryName === repositoryResourceId || item.repositoryName === repositoryResourceId2) {
+          await gitHubIamRoleResourceHandler.deleteResource({
+            resourceTypeId: "test-resource-type",
+            resourceId: item.repositoryName,
+          });
+        }
+      }
+    }
+
     await deleteAwsAccountDBItem(
       logger,
       tableNameForAWSAccount,
@@ -178,7 +209,7 @@ describe("Testing iamRolePromoteRequest", () => {
         {
           type: "permission",
           name: "Permission granted GitHub Repositories",
-          values: ["stamp-testRepository-promote"],
+          values: [repositoryResourceId],
         },
       ];
       const resultAsync = targetIamRoleResourceHandler.listResourceAuditItem(input);
@@ -206,7 +237,7 @@ describe("Testing iamRolePromoteRequest", () => {
           {
             type: "permission",
             name: "stamp-test-iam-role-promote" + " " + "IAM Role",
-            values: ["stamp-testRepository-promote GitHub IAM Role"],
+            values: [`${repositoryResourceId} GitHub IAM Role`],
           },
         ];
         const resultAsync = awsAccountResourceHandler.listResourceAuditItem(input);
@@ -283,12 +314,12 @@ describe("Testing iamRolePromoteRequest", () => {
           {
             type: "permission",
             name: "stamp-test-iam-role-promote" + " " + "IAM Role",
-            values: ["stamp-testRepository-promote GitHub IAM Role"],
+            values: [`${repositoryResourceId} GitHub IAM Role`],
           },
           {
             type: "permission",
             name: "stamp-test-iam-role-promote2" + " " + "IAM Role",
-            values: ["stamp-testRepository-promote2 GitHub IAM Role"],
+            values: [`${repositoryResourceId2} GitHub IAM Role`],
           },
         ];
         const resultAsync2 = awsAccountResourceHandler.listResourceAuditItem(input);

--- a/catalogs/iam-role/src/intergration-test/iamRolePromoteRequest.test.ts
+++ b/catalogs/iam-role/src/intergration-test/iamRolePromoteRequest.test.ts
@@ -15,11 +15,15 @@ const tableNameForJumpIamRole = `${process.env.IAM_ROLE_DYNAMO_TABLE_PREFIX}-iam
 
 const iamRoleFactoryAccountId = process.env.IAM_ROLE_FACTORY_AWS_ACCOUNT_ID!;
 const githubOrgName = process.env.GITHUB_ORG_NAME!;
+const repositoryName = "stamp-testRepository-promote";
+const repositoryName2 = "stamp-testRepository-promote2";
+const repositoryResourceId = `${githubOrgName}/${repositoryName}`;
+const repositoryResourceId2 = `${githubOrgName}/${repositoryName2}`;
 const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: `arn:aws:iam::${iamRoleFactoryAccountId}:role/stamp-execute-role`,
-  gitHubOrgName: githubOrgName,
+  gitHubOrgNames: [githubOrgName],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   awsAccountResourceTableName: tableNameForAWSAccount,
@@ -42,7 +46,7 @@ const approvedInput: ApprovedInput = {
   },
   inputResources: {
     "github-iam-role": {
-      resourceId: "stamp-testRepository-promote",
+      resourceId: repositoryResourceId,
       resourceTypeId: "test-resource-type",
     },
     "aws-account": {
@@ -78,11 +82,33 @@ describe("Testing iamRolePromoteRequest", () => {
     });
     await gitHubIamRoleResourceHandler.deleteResource({
       resourceTypeId: "test-resource-type",
-      resourceId: "stamp-testRepository-promote",
+      resourceId: repositoryResourceId,
+    });
+    // Also clean a possibly-leaked legacy record (bare repo name as PK) from
+    // earlier runs predating multi-org support; otherwise the createResource
+    // below is rejected by the legacy duplicate-PK guard.
+    await gitHubIamRoleResourceHandler.deleteResource({
+      resourceTypeId: "test-resource-type",
+      resourceId: repositoryName,
+    });
+    // Also clean leftover `promote2` records (compound + legacy) from prior
+    // runs of the multi-item pagination scenario; otherwise the single-item
+    // AwsAccountResource audit assertion sees two attached roles.
+    await gitHubIamRoleResourceHandler.deleteResource({
+      resourceTypeId: "test-resource-type",
+      resourceId: repositoryResourceId2,
+    });
+    await gitHubIamRoleResourceHandler.deleteResource({
+      resourceTypeId: "test-resource-type",
+      resourceId: repositoryName2,
     });
     await targetIamRoleResourceHandler.deleteResource({
       resourceTypeId: "test-resource-type",
       resourceId: "222233334444#stamp-test-iam-role-promote",
+    });
+    await targetIamRoleResourceHandler.deleteResource({
+      resourceTypeId: "test-resource-type",
+      resourceId: "222233334444#stamp-test-iam-role-promote2",
     });
     await createAwsAccountDBItem(
       logger,
@@ -95,7 +121,8 @@ describe("Testing iamRolePromoteRequest", () => {
     await gitHubIamRoleResourceHandler.createResource({
       resourceTypeId: "test-resource-type",
       inputParams: {
-        repositoryName: "stamp-testRepository-promote",
+        repositoryName: repositoryName,
+        gitHubOrgName: githubOrgName,
       },
     });
     await targetIamRoleResourceHandler.createResource({
@@ -117,7 +144,7 @@ describe("Testing iamRolePromoteRequest", () => {
     });
     await gitHubIamRoleResourceHandler.deleteResource({
       resourceTypeId: "test-resource-type",
-      resourceId: "stamp-testRepository-promote",
+      resourceId: repositoryResourceId,
     });
     await targetIamRoleResourceHandler.deleteResource({
       resourceTypeId: "test-resource-type",
@@ -204,7 +231,7 @@ describe("Testing iamRolePromoteRequest", () => {
           },
           inputResources: {
             "github-iam-role": {
-              resourceId: "stamp-testRepository-promote2",
+              resourceId: repositoryResourceId2,
               resourceTypeId: "test-resource-type",
             },
             "aws-account": {
@@ -231,7 +258,8 @@ describe("Testing iamRolePromoteRequest", () => {
         await gitHubIamRoleResourceHandler.createResource({
           resourceTypeId: "test-resource-type",
           inputParams: {
-            repositoryName: "stamp-testRepository-promote2",
+            repositoryName: repositoryName2,
+            gitHubOrgName: githubOrgName,
           },
         });
         await targetIamRoleResourceHandler.createResource({
@@ -329,7 +357,7 @@ describe("Testing iamRolePromoteRequest", () => {
         });
         await gitHubIamRoleResourceHandler.deleteResource({
           resourceTypeId: "test-resource-type",
-          resourceId: "stamp-testRepository-promote2",
+          resourceId: repositoryResourceId2,
         });
       });
     },
@@ -340,7 +368,7 @@ describe("Testing iamRolePromoteRequest", () => {
     it("returns successful result", async () => {
       const input: ListResourceAuditItemInput = {
         resourceTypeId: "test-resource-type",
-        resourceId: "stamp-testRepository-promote",
+        resourceId: repositoryResourceId,
       };
       const expected = [
         {

--- a/catalogs/iam-role/src/types/gitHubIamRole.ts
+++ b/catalogs/iam-role/src/types/gitHubIamRole.ts
@@ -37,9 +37,11 @@ export type CreatedGitHubIamRole = z.infer<typeof CreatedGitHubIamRole>;
  *
  * `gitHubRepositoryName` and `gitHubOrgName` are optional on the schema level
  * to allow legacy records (which only persisted `repositoryName`) to be parsed.
- * The read path is responsible for filling sensible fallbacks (e.g. splitting
- * the compound PK or defaulting the org to the first configured allow-list
- * entry) before returning to handlers.
+ * For legacy records the read path derives the bare repository name from the
+ * PK (which IS the bare name for legacy records) but does NOT infer the org —
+ * it is returned as `undefined` so callers must handle the missing value
+ * explicitly. Silently defaulting to the first allowlist entry was rejected as
+ * misleading (it could misattribute access to the wrong org).
  */
 export const GitHubIamRole = z.object({
   repositoryName: z.string(),

--- a/catalogs/iam-role/src/types/gitHubIamRole.ts
+++ b/catalogs/iam-role/src/types/gitHubIamRole.ts
@@ -1,7 +1,20 @@
 import { z } from "zod";
 
+/**
+ * Bare GitHub repository name (without org prefix). This is what the user
+ * enters in the create form and what we render in the UI. Must be non-empty.
+ */
+const GitHubRepositoryNameField = z.string().min(1);
+
+/**
+ * GitHub organization name. New resources require it; persisted records
+ * created before multi-org support may not have it (handled by the read path).
+ */
+const GitHubOrgNameField = z.string().min(1);
+
 export const CreateGitHubIamRoleNameCommand = z.object({
-  repositoryName: z.string(),
+  repositoryName: GitHubRepositoryNameField,
+  gitHubOrgName: GitHubOrgNameField,
 });
 export type CreateGitHubIamRoleNameCommand = z.infer<typeof CreateGitHubIamRoleNameCommand>;
 
@@ -14,7 +27,37 @@ export type CreateGitHubIamRoleCommand = z.infer<typeof CreateGitHubIamRoleComma
 export const CreatedGitHubIamRole = CreatedGitHubIamRoleName.merge(z.object({ iamRoleArn: z.string(), createdAt: z.string().datetime() }));
 export type CreatedGitHubIamRole = z.infer<typeof CreatedGitHubIamRole>;
 
-export const GitHubIamRole = CreatedGitHubIamRole;
+/**
+ * Persisted GitHub IAM Role record (DynamoDB item / Stamp resource).
+ *
+ * `repositoryName` here is the **DDB primary key value** and also the Stamp
+ * `resourceId`. For records created with multi-org support it is the compound
+ * `${gitHubOrgName}/${gitHubRepositoryName}`. For records created before
+ * multi-org support it is the bare repo name (legacy).
+ *
+ * `gitHubRepositoryName` and `gitHubOrgName` are optional on the schema level
+ * to allow legacy records (which only persisted `repositoryName`) to be parsed.
+ * The read path is responsible for filling sensible fallbacks (e.g. splitting
+ * the compound PK or defaulting the org to the first configured allow-list
+ * entry) before returning to handlers.
+ */
+export const GitHubIamRole = z.object({
+  repositoryName: z.string(),
+  // Lenient on the persisted side: empty strings from stale/leaked records or
+  // partial migrations must still parse. The handler-level read path applies
+  // sensible fallbacks before exposing values to callers.
+  gitHubRepositoryName: z
+    .string()
+    .optional()
+    .transform((v) => (v ? v : undefined)),
+  gitHubOrgName: z
+    .string()
+    .optional()
+    .transform((v) => (v ? v : undefined)),
+  iamRoleName: z.string(),
+  iamRoleArn: z.string(),
+  createdAt: z.string().datetime(),
+});
 export type GitHubIamRole = z.infer<typeof GitHubIamRole>;
 
 export const ListGitHubIamRoleAuditItemCommand = z.object({

--- a/catalogs/iam-role/vitest.config.ts
+++ b/catalogs/iam-role/vitest.config.ts
@@ -4,5 +4,15 @@ export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
     watch: false,
+    // Integration / handler tests perform several sequential AWS calls in
+    // beforeAll/afterAll (DynamoDB cleanup + IAM role create/delete). The
+    // default 10s hookTimeout is not enough; bumping globally avoids
+    // sprinkling per-hook timeouts across every file.
+    hookTimeout: 120_000,
+    testTimeout: 300_000,
+    // Several integration files share the same IAM role names to exercise
+    // realistic flows. Running them in parallel causes EntityAlreadyExists
+    // / NoSuchEntity races on AWS resources, so we serialize file execution.
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### 🎉 Reason for this change

The `github-iam-role` catalog previously supported only a single GitHub organization (set via `config.gitHubOrgName`), which made it impossible to on-board repositories from multiple orgs in the same Stamp deployment. Letting users free-type the org name would be unsafe — a typo would silently create a trust policy for the wrong organization, which is a security incident waiting to happen.

This change adds an allowlist-based mechanism so a deployment can configure multiple GitHub organizations explicitly, and users pick from the allowlist when on-boarding a resource.

### 🔀 Description of changes

**Config**
- `config.gitHubOrgName` (singular, string) replaced by `config.gitHubOrgNames` (non-empty `string[]`).

**Resource handler (`github-iam-role`)**
- Added `gitHubOrgName` as a required `createParam`; the handler validates it against `config.gitHubOrgNames` and rejects values not on the allowlist.
- New records persist with a compound DynamoDB primary key `${gitHubOrgName}/${repositoryName}` plus new `gitHubOrgName` / `gitHubRepositoryName` attributes, so the same repo name can be on-boarded under different orgs.
- IAM role names and trust policies continue to embed the chosen org (`${roleNamePrefix}-github-${org}-${repo}` / `repo:${org}/${repo}:*`).

**Backwards compatibility**
- Legacy records (bare `${repositoryName}` PK, no org attribute) remain readable and deletable via direct string lookup; both PK shapes coexist.
- Legacy records expose `gitHubOrgName` as `undefined` rather than silently falling back to `gitHubOrgNames[0]` — silent attribution to the wrong org was rejected as misleading.
- Audit views (`awsAccountResource.listResourceAuditItem`, `targetIamRoleResource.listResourceAuditItem`) display the PK as-is so identically named repos under different orgs remain distinguishable (the GSI is `KEYS_ONLY`, so the PK is the source of truth).
- DynamoDB schema (`cf-db-template.yaml`) is unchanged; the new attributes are additive.

**Idempotent delete handlers**
- `deleteGitHubIamRoleInAws`, `deleteJumpIamRoleInAws`, and `deleteAssumeRolePolicy` now treat `NoSuchEntity` as success so orphaned DynamoDB records can be cleaned up without manual AWS intervention.

**Test execution**
- Added `vitest.config.ts` with `fileParallelism: false`, `hookTimeout: 120_000`, `testTimeout: 300_000` because integration tests share IAM role names and run against real AWS APIs.

### 🖨️ Description of how you validated changes

`npm run test` in `catalogs/iam-role/` (260 tests across 22 files, all passing).

### 👀 Points to be checked especially by reviewers (if any)

N/A

### 🔗 Related links

N/A
