### PR TITLE
feat(iam-role): support GitHub immutable OIDC subject claims and multiple roles per repository

### DIFF
--- a/catalogs/iam-role/README.md
+++ b/catalogs/iam-role/README.md
@@ -115,9 +115,6 @@ createIamRoleCatalog({
 });
 ```
 
-> **Breaking change**: this field replaced `gitHubOrgNames: string[]`. Existing
-> deployments must update their configuration when upgrading.
-
 When a user creates a `github-iam-role` resource they provide:
 
 | param | required | description |

--- a/catalogs/iam-role/README.md
+++ b/catalogs/iam-role/README.md
@@ -43,6 +43,10 @@ standard AWS SDK credential source):
 | `JUMP_IAM_ROLE_ATTACHED_POLICY_ARN` | ARN of a managed policy used by `jump-iam-role` tests |
 | `ORIGIN_IAM_ROLE_ARN` | ARN of an IAM role used as the trust origin in `jump-iam-role` tests |
 
+GitHub organization / repository IDs are fixed fixtures inside the tests (IAM
+and DynamoDB never validate the sub-claim contents against GitHub), so no
+additional environment variables are needed for the immutable-claims support.
+
 Then run:
 
 ```bash
@@ -91,33 +95,104 @@ organization names from users. Instead, the catalog configuration declares an
 allow-list of organizations, and at resource creation time the user must pick
 one of them.
 
-##### `gitHubOrgNames`
+##### `gitHubOrgs`
+
+Each allow-list entry pairs the organization name with its **immutable numeric
+organization ID** (as a decimal string). The ID is embedded in the OIDC trust
+policy (see below). Obtain it with:
+
+```bash
+curl -s https://api.github.com/orgs/my-org | jq .id
+```
 
 ```ts
 createIamRoleCatalog({
   // ...other fields...
-  gitHubOrgNames: ["my-org", "my-other-org"],
+  gitHubOrgs: [
+    { name: "my-org", id: "1234567" },
+    { name: "my-other-org", id: "7654321" },
+  ],
 });
 ```
 
-When a user creates a `github-iam-role` resource they choose `gitHubOrgName`
-(required) and `repositoryName`. The handler rejects any value not in
-`gitHubOrgNames`.
+> **Breaking change**: this field replaced `gitHubOrgNames: string[]`. Existing
+> deployments must update their configuration when upgrading.
+
+When a user creates a `github-iam-role` resource they provide:
+
+| param | required | description |
+| --- | --- | --- |
+| `gitHubOrgName` | ✓ | Must be one of the configured `gitHubOrgs` names. |
+| `repositoryName` | ✓ | Bare repository name (without org prefix). |
+| `repositoryId` | ✓ | Immutable numeric repository ID: `curl -s https://api.github.com/repos/{owner}/{repo} \| jq .id` |
+| `roleSuffix` | – | 1-32 chars (`[a-zA-Z0-9-]`, must start/end alphanumeric). Distinguishes multiple IAM roles for the same repository. |
+| `subjectType` | – | Defaults to `repository` (whole-repo scope). Other scopes (branch / environment / tag / pull_request) are planned but not yet supported. |
+
+#### Immutable OIDC subject claims
+
+GitHub [changed the OIDC token `sub` claim](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/)
+to embed immutable numeric IDs: `repo:ORG@ORG_ID/REPO@REPO_ID:ref:...`.
+Since **2026-07-15**, all newly created, renamed, or transferred repositories
+on github.com emit this format unconditionally; pre-existing repositories keep
+the legacy `repo:ORG/REPO:...` format unless opted in.
+
+This catalog writes trust policies that match **only the new format**:
+
+```json
+"Condition": {
+  "StringLike": {
+    "token.actions.githubusercontent.com:sub": "repo:my-org@1234567/my-repo@9876543:*"
+  }
+}
+```
+
+Consequences:
+
+- **Tokens from repositories still on the legacy format will NOT match roles
+  created by this catalog.** The repository must be opted in to immutable
+  subject claims (or be newly created / renamed after 2026-07-15).
+- **Roles created before this feature keep their legacy-format trust policy
+  and are not migrated.** A trust policy is written once at role creation and
+  never updated (`updateResource` is not implemented). To migrate an existing
+  role, delete the resource and recreate it with `repositoryId`. If you omit
+  `roleSuffix`, the recreated IAM role has the **same role name and ARN**, so
+  GitHub workflow definitions referencing the ARN do not need to change.
+- **A wrong `repositoryId` fails closed**: the catalog does not call the
+  GitHub API to verify the ID, so a typo produces a role that can never be
+  assumed (no token will carry that org/repo/ID combination). Delete and
+  recreate with the correct ID.
+
+#### Multiple roles per repository (`roleSuffix`)
+
+Passing `roleSuffix` creates an additional, independent IAM role for a
+repository:
+
+- IAM role name: `${roleNamePrefix}-github-${org}-${repo}-${roleSuffix}`
+- resourceId / display name: `${org}/${repo}/${roleSuffix}`
+
+Omitting `roleSuffix` keeps the original single-role naming, which preserves
+role names/ARNs across delete-and-recreate migrations.
 
 ### Behavior notes
 
 - IAM role name format remains `${roleNamePrefix}-github-${gitHubOrgName}-${repositoryName}`
-  (the org name is taken from the per-resource choice, not from a single
-  config field). The 64-character IAM role name limit still applies; pick
-  shorter `roleNamePrefix` / repo names when on-boarding orgs with long names.
-- New resources created under multi-org support use a compound `resourceId` of
-  the form `${gitHubOrgName}/${repositoryName}` so that the same repository
-  name can be on-boarded under different orgs. Resources created before
-  multi-org support keep their bare `${repositoryName}` resourceId; both are
+  (with `-${roleSuffix}` appended when given). The 64-character IAM role name
+  limit still applies and the suffix counts toward it; pick shorter
+  `roleNamePrefix` / repo names / suffixes when on-boarding orgs with long names.
+- New resources use a compound `resourceId` of the form
+  `${gitHubOrgName}/${repositoryName}` (or `${gitHubOrgName}/${repositoryName}/${roleSuffix}`)
+  so that the same repository name can be on-boarded under different orgs and
+  multiple roles can exist per repository. Resources created before
+  multi-org support keep their bare `${repositoryName}` resourceId; all forms are
   resolved correctly by `getResource` / `deleteResource` / promote requests.
 - DynamoDB schema (`cf-db-template.yaml`) is unchanged. New attributes
-  (`gitHubRepositoryName`, `gitHubOrgName`) are written to records created with
-  multi-org support; legacy records without those attributes are still readable.
+  (`gitHubRepositoryName`, `gitHubOrgName`, `gitHubRepositoryId`, `gitHubOrgId`,
+  `roleSuffix`, `subjectType`, `subject`) are written to newly created records;
+  legacy records without those attributes are still readable. The persisted
+  `subject` records the exact sub condition written to the trust policy for
+  auditability. Record creation now uses a conditional put
+  (`attribute_not_exists`) so a concurrent duplicate create fails instead of
+  silently overwriting.
   Note that legacy records expose `gitHubOrgName` as `undefined` (the org cannot
   be safely inferred — a silent fallback could mislead operators), so consumers
   must handle the missing value. The bare `repositoryName` for legacy records is
@@ -135,10 +210,11 @@ When a user creates a `github-iam-role` resource they choose `gitHubOrgName`
 
 - The current `ResourceCreateParam` schema in `@stamp-lib/stamp-types` only
   supports primitive types (no `enum`), so the web UI still presents
-  `gitHubOrgName` as a free-text input. The catalog handler validates the
-  value against `gitHubOrgNames` server-side and rejects anything not on the
-  allow-list, so the allow-list is enforced — but UX could be improved by
-  promoting `ResourceCreateParam` to support enum selection (out of scope for
+  `gitHubOrgName` / `subjectType` as free-text inputs. The catalog handler
+  validates the values server-side (org against `gitHubOrgs`, `repositoryId`
+  as a numeric string, `roleSuffix` charset, `subjectType` enum) and rejects
+  anything invalid — but UX could be improved by promoting
+  `ResourceCreateParam` to support enum selection (out of scope for
   this catalog).
 - Because new resourceIds contain a `/`, anywhere the resourceId is
   embedded in a URL must URL-encode it (`encodeURIComponent`). The Stamp

--- a/catalogs/iam-role/src/config.test.ts
+++ b/catalogs/iam-role/src/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { IamRoleCatalogConfig, IamRoleCatalogConfigInput } from "./config";
+import { IamRoleCatalogConfig, IamRoleCatalogConfigInput, findAllowedGitHubOrg } from "./config";
 
 const baseConfigInput = {
   region: "us-west-2",
@@ -15,22 +15,75 @@ const baseConfigInput = {
 
 describe("IamRoleCatalogConfig", () => {
   it("accepts a single allowed org", () => {
-    const cfg = IamRoleCatalogConfig.parse({ ...baseConfigInput, gitHubOrgNames: ["org-a"] });
-    expect(cfg.gitHubOrgNames).toEqual(["org-a"]);
+    const cfg = IamRoleCatalogConfig.parse({ ...baseConfigInput, gitHubOrgs: [{ name: "org-a", id: "111" }] });
+    expect(cfg.gitHubOrgs).toEqual([{ name: "org-a", id: "111" }]);
   });
 
   it("accepts multiple allowed orgs", () => {
-    const cfg = IamRoleCatalogConfig.parse({ ...baseConfigInput, gitHubOrgNames: ["org-a", "org-b"] });
-    expect(cfg.gitHubOrgNames).toEqual(["org-a", "org-b"]);
+    const cfg = IamRoleCatalogConfig.parse({
+      ...baseConfigInput,
+      gitHubOrgs: [
+        { name: "org-a", id: "111" },
+        { name: "org-b", id: "222" },
+      ],
+    });
+    expect(cfg.gitHubOrgs).toEqual([
+      { name: "org-a", id: "111" },
+      { name: "org-b", id: "222" },
+    ]);
   });
 
-  it("rejects when gitHubOrgNames is missing", () => {
+  it("rejects when gitHubOrgs is missing", () => {
     const result = IamRoleCatalogConfig.safeParse(baseConfigInput);
     expect(result.success).toBe(false);
   });
 
-  it("rejects an empty gitHubOrgNames array", () => {
-    const result = IamRoleCatalogConfig.safeParse({ ...baseConfigInput, gitHubOrgNames: [] });
+  it("rejects the pre-immutable-claims gitHubOrgNames shape", () => {
+    const result = IamRoleCatalogConfig.safeParse({ ...baseConfigInput, gitHubOrgNames: ["org-a"] });
     expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty gitHubOrgs array", () => {
+    const result = IamRoleCatalogConfig.safeParse({ ...baseConfigInput, gitHubOrgs: [] });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an org with an empty name", () => {
+    const result = IamRoleCatalogConfig.safeParse({ ...baseConfigInput, gitHubOrgs: [{ name: "", id: "111" }] });
+    expect(result.success).toBe(false);
+  });
+
+  it.each(["", "abc", "12a", "1.5", " 123"])("rejects a non-numeric org id (%j)", (id) => {
+    const result = IamRoleCatalogConfig.safeParse({ ...baseConfigInput, gitHubOrgs: [{ name: "org-a", id }] });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects duplicate org names (ambiguous name→id lookup)", () => {
+    const result = IamRoleCatalogConfig.safeParse({
+      ...baseConfigInput,
+      gitHubOrgs: [
+        { name: "org-a", id: "111" },
+        { name: "org-a", id: "222" },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("findAllowedGitHubOrg", () => {
+  const cfg = IamRoleCatalogConfig.parse({
+    ...baseConfigInput,
+    gitHubOrgs: [
+      { name: "org-a", id: "111" },
+      { name: "org-b", id: "222" },
+    ],
+  });
+
+  it("returns the matching org with its id", () => {
+    expect(findAllowedGitHubOrg(cfg, "org-b")).toEqual({ name: "org-b", id: "222" });
+  });
+
+  it("returns undefined for an org not in the allow-list", () => {
+    expect(findAllowedGitHubOrg(cfg, "org-c")).toBeUndefined();
   });
 });

--- a/catalogs/iam-role/src/config.ts
+++ b/catalogs/iam-role/src/config.ts
@@ -1,5 +1,18 @@
 import { z } from "zod";
 
+/**
+ * A GitHub organization allowed to on-board repositories as `github-iam-role`
+ * resources. `id` is the immutable numeric organization ID (as a decimal
+ * string, to avoid int64 precision issues) required by GitHub's immutable
+ * OIDC subject claims (`repo:ORG@ORG_ID/REPO@REPO_ID:...`). Obtain it via
+ * `GET https://api.github.com/orgs/{org}` (`id` field).
+ */
+export const GitHubOrg = z.object({
+  name: z.string().min(1),
+  id: z.string().regex(/^[0-9]+$/, "GitHub organization ID must be a numeric string"),
+});
+export type GitHubOrg = z.infer<typeof GitHubOrg>;
+
 export const IamRoleCatalogConfig = z.object({
   region: z.string(),
   iamRoleFactoryAccountId: z.string(),
@@ -9,8 +22,21 @@ export const IamRoleCatalogConfig = z.object({
    * `github-iam-role` resources. Users must pick one of these values when
    * creating a resource. Configuring an explicit allow-list (instead of letting
    * users type any org name) prevents typo-driven security incidents.
+   * Duplicate names are rejected because two entries with the same name but
+   * different IDs would make the name→ID lookup ambiguous.
    */
-  gitHubOrgNames: z.array(z.string().min(1)).nonempty(),
+  gitHubOrgs: z
+    .array(GitHubOrg)
+    .nonempty()
+    .superRefine((orgs, ctx) => {
+      const names = new Set<string>();
+      for (const org of orgs) {
+        if (names.has(org.name)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: `Duplicate GitHub organization "${org.name}"` });
+        }
+        names.add(org.name);
+      }
+    }),
   policyNamePrefix: z.string(),
   roleNamePrefix: z.string(),
   awsAccountResourceTableName: z.string(),
@@ -21,3 +47,10 @@ export const IamRoleCatalogConfig = z.object({
 });
 export type IamRoleCatalogConfigInput = z.input<typeof IamRoleCatalogConfig>;
 export type IamRoleCatalogConfig = z.output<typeof IamRoleCatalogConfig>;
+
+/**
+ * Looks up a GitHub organization in the configured allow-list by name.
+ * Returns `undefined` when the org is not allowed.
+ */
+export const findAllowedGitHubOrg = (config: IamRoleCatalogConfig, gitHubOrgName: string): GitHubOrg | undefined =>
+  config.gitHubOrgs.find((org) => org.name === gitHubOrgName);

--- a/catalogs/iam-role/src/events/database/gitHubIamRoleDB.test.ts
+++ b/catalogs/iam-role/src/events/database/gitHubIamRoleDB.test.ts
@@ -21,6 +21,11 @@ const config = { region: "us-west-2" };
 const githubOrgName = process.env.GITHUB_ORG_NAME!;
 const testBareRepoName = "stamp-testRepository";
 const testPkValue = buildGitHubIamRolePkValue(githubOrgName, testBareRepoName);
+// Fixed fixtures: DynamoDB never validates these against GitHub, so any
+// numeric strings work for integration tests.
+const testRepositoryId = "9876543";
+const testGitHubOrgId = "1234567";
+const testSubject = `repo:${githubOrgName}@${testGitHubOrgId}/${testBareRepoName}@${testRepositoryId}:*`;
 
 describe("Testing gitHubIamRoleDB", () => {
   const logger = createLogger("DEBUG", { moduleName: "iam-role" });
@@ -43,6 +48,10 @@ describe("Testing gitHubIamRoleDB", () => {
       const input: CreatedGitHubIamRole = {
         repositoryName: "",
         gitHubOrgName: githubOrgName,
+        repositoryId: testRepositoryId,
+        gitHubOrgId: testGitHubOrgId,
+        subjectType: "repository",
+        subject: testSubject,
         iamRoleName: `test-github-${githubOrgName}-test-repository`,
         iamRoleArn: "arn:aws:iam::123456789012:role/test-service-role",
         createdAt: "2024-01-02T03:04:05.006Z",
@@ -56,6 +65,10 @@ describe("Testing gitHubIamRoleDB", () => {
       const input: CreatedGitHubIamRole = {
         repositoryName: testBareRepoName,
         gitHubOrgName: githubOrgName,
+        repositoryId: testRepositoryId,
+        gitHubOrgId: testGitHubOrgId,
+        subjectType: "repository",
+        subject: testSubject,
         iamRoleName: "",
         iamRoleArn: "arn:aws:iam::123456789012:role/test-service-role",
         createdAt: "2024-01-02T03:04:05.006Z",
@@ -69,6 +82,10 @@ describe("Testing gitHubIamRoleDB", () => {
       const input: CreatedGitHubIamRole = {
         repositoryName: testBareRepoName,
         gitHubOrgName: githubOrgName,
+        repositoryId: testRepositoryId,
+        gitHubOrgId: testGitHubOrgId,
+        subjectType: "repository",
+        subject: testSubject,
         iamRoleName: `test-github-${githubOrgName}-test-repository`,
         iamRoleArn: "",
         createdAt: "2024-01-02T03:04:05.006Z",
@@ -76,12 +93,19 @@ describe("Testing gitHubIamRoleDB", () => {
       const resultAsync = createGitHubIamRoleDBItem(logger, tableName, config)(input);
       const result = await resultAsync;
       expect(result.isOk()).toBe(true);
+      // Clean up: the create below writes the same PK and PutCommand now uses
+      // attribute_not_exists (no silent overwrite).
+      await deleteGitHubIamRoleDBItem(logger, tableName, config)({ repositoryName: testPkValue });
     });
 
     it("returns failed result if creation date is invalid", async () => {
       const input: CreatedGitHubIamRole = {
         repositoryName: testBareRepoName,
         gitHubOrgName: githubOrgName,
+        repositoryId: testRepositoryId,
+        gitHubOrgId: testGitHubOrgId,
+        subjectType: "repository",
+        subject: testSubject,
         iamRoleName: `test-github-${githubOrgName}-test-repository`,
         iamRoleArn: "arn:aws:iam::123456789012:role/test-service-role",
         createdAt: "",
@@ -95,6 +119,10 @@ describe("Testing gitHubIamRoleDB", () => {
       const input: CreatedGitHubIamRole = {
         repositoryName: testBareRepoName,
         gitHubOrgName: githubOrgName,
+        repositoryId: testRepositoryId,
+        gitHubOrgId: testGitHubOrgId,
+        subjectType: "repository",
+        subject: testSubject,
         iamRoleName: `test-github-${githubOrgName}-test-repository`,
         iamRoleArn: "arn:aws:iam::123456789012:role/test-service-role",
         createdAt: "2024-01-02T03:04:05.006Z",
@@ -103,6 +131,10 @@ describe("Testing gitHubIamRoleDB", () => {
         repositoryName: testPkValue,
         gitHubRepositoryName: testBareRepoName,
         gitHubOrgName: githubOrgName,
+        gitHubRepositoryId: testRepositoryId,
+        gitHubOrgId: testGitHubOrgId,
+        subjectType: "repository",
+        subject: testSubject,
         iamRoleName: `test-github-${githubOrgName}-test-repository`,
         iamRoleArn: "arn:aws:iam::123456789012:role/test-service-role",
         createdAt: "2024-01-02T03:04:05.006Z",
@@ -115,6 +147,22 @@ describe("Testing gitHubIamRoleDB", () => {
       const gitHubIamRole = result.value;
       expect(gitHubIamRole).toEqual(expected);
     });
+
+    it("returns failed result when the same PK already exists (no silent overwrite)", async () => {
+      const input: CreatedGitHubIamRole = {
+        repositoryName: testBareRepoName,
+        gitHubOrgName: githubOrgName,
+        repositoryId: testRepositoryId,
+        gitHubOrgId: testGitHubOrgId,
+        subjectType: "repository",
+        subject: testSubject,
+        iamRoleName: `test-github-${githubOrgName}-test-repository`,
+        iamRoleArn: "arn:aws:iam::123456789012:role/test-service-role",
+        createdAt: "2024-01-02T03:04:05.006Z",
+      };
+      const result = await createGitHubIamRoleDBItem(logger, tableName, config)(input);
+      expect(result.isErr()).toBe(true);
+    });
   });
 
   describe("getGitHubIamRoleDBItem", () => {
@@ -126,6 +174,10 @@ describe("Testing gitHubIamRoleDB", () => {
         repositoryName: testPkValue,
         gitHubRepositoryName: testBareRepoName,
         gitHubOrgName: githubOrgName,
+        gitHubRepositoryId: testRepositoryId,
+        gitHubOrgId: testGitHubOrgId,
+        subjectType: "repository",
+        subject: testSubject,
         iamRoleArn: "arn:aws:iam::123456789012:role/test-service-role",
         iamRoleName: `test-github-${githubOrgName}-test-repository`,
         createdAt: "2024-01-02T03:04:05.006Z",

--- a/catalogs/iam-role/src/events/database/gitHubIamRoleDB.ts
+++ b/catalogs/iam-role/src/events/database/gitHubIamRoleDB.ts
@@ -20,21 +20,25 @@ import { Logger } from "@stamp-lib/stamp-logger";
  * Builds the DynamoDB primary-key value (also the Stamp `resourceId`) for a
  * GitHub IAM Role resource. With multi-org support the PK is the compound
  * `${gitHubOrgName}/${repositoryName}` so that the same repo name can exist
- * under different orgs without collision.
+ * under different orgs without collision. An optional role suffix extends it
+ * to `${gitHubOrgName}/${repositoryName}/${roleSuffix}` so that multiple IAM
+ * roles can exist for the same repository.
  */
-export const buildGitHubIamRolePkValue = (gitHubOrgName: string, repositoryName: string): string => `${gitHubOrgName}/${repositoryName}`;
+export const buildGitHubIamRolePkValue = (gitHubOrgName: string, repositoryName: string, roleSuffix?: string): string =>
+  roleSuffix ? `${gitHubOrgName}/${repositoryName}/${roleSuffix}` : `${gitHubOrgName}/${repositoryName}`;
 
 /**
  * Extracts the bare repository name from the persisted primary-key value.
- * Multi-org records use the compound form `${org}/${repo}`; legacy single-org
- * records store the bare repo name as PK directly. Neither GitHub org names
- * nor repository names may contain `/`, so splitting on the first `/` is
- * unambiguous. Useful when only the PK is available (e.g. when reading via
- * the `IamRoleNameIndex` GSI which has `KEYS_ONLY` projection).
+ * Multi-org records use the compound form `${org}/${repo}` (optionally
+ * `${org}/${repo}/${suffix}`); legacy single-org records store the bare repo
+ * name as PK directly. Neither GitHub org names nor repository names may
+ * contain `/`, so the repo name is always the second segment when a `/` is
+ * present. Useful when only the PK is available (e.g. when reading via the
+ * `IamRoleNameIndex` GSI which has `KEYS_ONLY` projection).
  */
 export const extractBareRepositoryName = (pkValue: string): string => {
-  const idx = pkValue.indexOf("/");
-  return idx === -1 ? pkValue : pkValue.slice(idx + 1);
+  const segments = pkValue.split("/");
+  return segments.length === 1 ? segments[0] : segments[1];
 };
 
 export type GetGitHubIamRoleDBItemInput = { repositoryName: string };
@@ -132,13 +136,19 @@ export const createGitHubIamRoleDBItem =
     if (!inputValidation.success) {
       return errAsync(new HandlerError(`Failed to parse input.: ${inputValidation.error.toString()}`, "INTERNAL_SERVER_ERROR"));
     }
-    // Persist with the compound primary key (`${org}/${bareRepo}`) so that
-    // resources with identical bare repo names across different orgs do not
-    // collide.
+    // Persist with the compound primary key (`${org}/${bareRepo}` or
+    // `${org}/${bareRepo}/${roleSuffix}`) so that resources with identical
+    // bare repo names across different orgs — and multiple roles for the same
+    // repo — do not collide.
     const itemInput: GitHubIamRole = {
-      repositoryName: buildGitHubIamRolePkValue(input.gitHubOrgName, input.repositoryName),
+      repositoryName: buildGitHubIamRolePkValue(input.gitHubOrgName, input.repositoryName, input.roleSuffix),
       gitHubRepositoryName: input.repositoryName,
       gitHubOrgName: input.gitHubOrgName,
+      gitHubRepositoryId: input.repositoryId,
+      gitHubOrgId: input.gitHubOrgId,
+      roleSuffix: input.roleSuffix,
+      subjectType: input.subjectType,
+      subject: input.subject,
       iamRoleName: input.iamRoleName,
       iamRoleArn: input.iamRoleArn,
       createdAt: input.createdAt,
@@ -150,9 +160,15 @@ export const createGitHubIamRoleDBItem =
     const param = {
       TableName: tableName,
       Item: perseResult.data,
+      // The handler pre-checks for an existing PK, but that check is not
+      // atomic with this write. Fail loudly instead of silently overwriting a
+      // concurrent create's record (which would orphan its IAM role).
+      ConditionExpression: "attribute_not_exists(repositoryName)",
     };
     const client = new DynamoDBClient(DynamoDBClientConfig);
-    const ddbDocClient = DynamoDBDocumentClient.from(client);
+    // removeUndefinedValues: optional attributes (roleSuffix etc.) may be
+    // undefined and must be dropped rather than fail marshalling.
+    const ddbDocClient = DynamoDBDocumentClient.from(client, { marshallOptions: { removeUndefinedValues: true } });
     const command = new PutCommand(param);
 
     return ResultAsync.fromPromise(ddbDocClient.send(command), (err) => {

--- a/catalogs/iam-role/src/events/resource/gitHubIamRole.test.ts
+++ b/catalogs/iam-role/src/events/resource/gitHubIamRole.test.ts
@@ -20,7 +20,7 @@ const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: accountId,
   iamRoleFactoryAccountRoleArn: "test-arn",
-  gitHubOrgNames: [githubOrgName],
+  gitHubOrgs: [{ name: githubOrgName, id: "1234567" }],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   awsAccountResourceTableName: `${process.env.IAM_ROLE_DYNAMO_TABLE_PREFIX}-iam-role-AWSAccountResource`,
@@ -35,7 +35,7 @@ const deleteGitHubIamRoleForTest = async (logger: Logger) => {
   const input: GitHubIamRole = {
     gitHubOrgName: githubOrgName,
     repositoryName: "test-Repository",
-    iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgNames[0]}-test-Repository`,
+    iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgs[0].name}-test-Repository`,
     iamRoleArn: "test-arn",
     createdAt: "2024-01-02T03:04:05.006Z",
   };
@@ -57,11 +57,18 @@ describe("Testing gitHubIamRole", () => {
       const input: CreateGitHubIamRoleNameCommand = {
         gitHubOrgName: githubOrgName,
         repositoryName: "1".repeat(44), // number of characters within range excluding prefix etc
+        repositoryId: "9876543",
+        subjectType: "repository",
       };
       const expected: CreatedGitHubIamRoleName = {
         gitHubOrgName: githubOrgName,
         repositoryName: "1".repeat(44), // number of characters within range excluding prefix etc
-        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgNames[0]}-` + "1".repeat(44),
+        repositoryId: "9876543",
+        gitHubOrgId: config.gitHubOrgs[0].id,
+        roleSuffix: undefined,
+        subjectType: "repository",
+        subject: `repo:${githubOrgName}@${config.gitHubOrgs[0].id}/${"1".repeat(44)}@9876543:*`,
+        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgs[0].name}-` + "1".repeat(44),
       };
       const result = createGitHubIamRoleName(config)(input);
       if (result.isErr()) {
@@ -74,6 +81,8 @@ describe("Testing gitHubIamRole", () => {
       const input: CreateGitHubIamRoleNameCommand = {
         gitHubOrgName: githubOrgName,
         repositoryName: "1".repeat(44) + "a", // number of characters exceeding range limit
+        repositoryId: "9876543",
+        subjectType: "repository",
       };
       const result = createGitHubIamRoleName(config)(input);
       expect(result.isErr()).toBe(true);
@@ -83,6 +92,8 @@ describe("Testing gitHubIamRole", () => {
       const input: CreateGitHubIamRoleNameCommand = {
         gitHubOrgName: githubOrgName,
         repositoryName: "",
+        repositoryId: "9876543",
+        subjectType: "repository",
       };
       const result = createGitHubIamRoleName(config)(input);
       expect(result.isErr()).toBe(true);
@@ -96,12 +107,20 @@ describe("Testing gitHubIamRole", () => {
       const input: CreateGitHubIamRoleCommand = {
         gitHubOrgName: githubOrgName,
         repositoryName: "test-Repository",
-        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgNames[0]}-test-Repository`,
+        repositoryId: "9876543",
+        gitHubOrgId: config.gitHubOrgs[0].id,
+        subjectType: "repository",
+        subject: `repo:${githubOrgName}@${config.gitHubOrgs[0].id}/test-Repository@9876543:*`,
+        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgs[0].name}-test-Repository`,
       };
       const expected: CreatedGitHubIamRole = {
         gitHubOrgName: githubOrgName,
         repositoryName: "test-Repository",
-        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgNames[0]}-test-Repository`,
+        repositoryId: "9876543",
+        gitHubOrgId: config.gitHubOrgs[0].id,
+        subjectType: "repository",
+        subject: `repo:${githubOrgName}@${config.gitHubOrgs[0].id}/test-Repository@9876543:*`,
+        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgs[0].name}-test-Repository`,
         iamRoleArn: expect.any(String),
         createdAt: expect.any(String),
       };
@@ -118,7 +137,11 @@ describe("Testing gitHubIamRole", () => {
       const input: CreateGitHubIamRoleCommand = {
         gitHubOrgName: githubOrgName,
         repositoryName: "",
-        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgNames[0]}-test-Repository`,
+        repositoryId: "9876543",
+        gitHubOrgId: config.gitHubOrgs[0].id,
+        subjectType: "repository",
+        subject: `repo:${githubOrgName}@${config.gitHubOrgs[0].id}/@9876543:*`,
+        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgs[0].name}-test-Repository`,
       };
       const resultAsync = createGitHubIamRoleInAws(logger, config, iamClient)(input);
       const result = await resultAsync;
@@ -130,6 +153,10 @@ describe("Testing gitHubIamRole", () => {
       const input: CreateGitHubIamRoleCommand = {
         gitHubOrgName: githubOrgName,
         repositoryName: "test-Repository",
+        repositoryId: "9876543",
+        gitHubOrgId: config.gitHubOrgs[0].id,
+        subjectType: "repository",
+        subject: `repo:${githubOrgName}@${config.gitHubOrgs[0].id}/test-Repository@9876543:*`,
         iamRoleName: "",
       };
       const resultAsync = createGitHubIamRoleInAws(logger, config, iamClient)(input);
@@ -178,7 +205,7 @@ describe("Testing gitHubIamRole", () => {
       const input: GitHubIamRole = {
         gitHubOrgName: githubOrgName,
         repositoryName: "test-Repository",
-        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgNames[0]}-test-Repository`,
+        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgs[0].name}-test-Repository`,
         iamRoleArn: "test-arn",
         createdAt: "2024-01-02T03:04:05.006Z",
       };
@@ -196,7 +223,7 @@ describe("Testing gitHubIamRole", () => {
       const input: GitHubIamRole = {
         gitHubOrgName: githubOrgName,
         repositoryName: "",
-        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgNames[0]}-test-Repository`,
+        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgs[0].name}-test-Repository`,
         iamRoleArn: "test-arn",
         createdAt: "2024-01-02T03:04:05.006Z",
       };
@@ -225,7 +252,7 @@ describe("Testing gitHubIamRole", () => {
       const input: GitHubIamRole = {
         gitHubOrgName: githubOrgName,
         repositoryName: "test-Repository",
-        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgNames[0]}-test-Repository`,
+        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgs[0].name}-test-Repository`,
         iamRoleArn: "",
         createdAt: "2024-01-02T03:04:05.006Z",
       };
@@ -239,7 +266,7 @@ describe("Testing gitHubIamRole", () => {
       const input: GitHubIamRole = {
         gitHubOrgName: githubOrgName,
         repositoryName: "test-Repository",
-        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgNames[0]}-test-Repository`,
+        iamRoleName: `${config.roleNamePrefix}-github-${config.gitHubOrgs[0].name}-test-Repository`,
         iamRoleArn: "test-arn",
         createdAt: "",
       };

--- a/catalogs/iam-role/src/events/resource/gitHubIamRole.ts
+++ b/catalogs/iam-role/src/events/resource/gitHubIamRole.ts
@@ -2,7 +2,7 @@ import { CreateRoleCommand, DeleteRoleCommand, GetPolicyCommand, GetPolicyVersio
 import { Logger } from "@stamp-lib/stamp-logger";
 import { HandlerError } from "@stamp-lib/stamp-types/catalogInterface/handler";
 import { Result, ResultAsync, err, errAsync, ok, okAsync } from "neverthrow";
-import { IamRoleCatalogConfig } from "../../config";
+import { IamRoleCatalogConfig, findAllowedGitHubOrg } from "../../config";
 import {
   CreateGitHubIamRoleCommand,
   CreateGitHubIamRoleNameCommand,
@@ -11,7 +11,34 @@ import {
   GitHubIamRole,
   ListGitHubIamRoleAuditItem,
   ListGitHubIamRoleAuditItemCommand,
+  SubjectType,
 } from "../../types/gitHubIamRole";
+
+/**
+ * Assembles the OIDC subject claim condition using GitHub's immutable format
+ * (`repo:ORG@ORG_ID/REPO@REPO_ID:...`). Since 2026-07-15 all newly created,
+ * renamed, or transferred repositories on github.com emit this format, so the
+ * trust policy must match on it. Tokens from repositories still on the legacy
+ * name-only format will NOT match roles created with this condition — such
+ * repositories must opt in to the immutable format first.
+ *
+ * Only the whole-repository scope is supported today; the signature accepts
+ * `subjectType` so branch / environment / tag / pull_request scoping can be
+ * added without changing call sites.
+ */
+export const buildGitHubSubjectClaim = (input: {
+  gitHubOrgName: string;
+  gitHubOrgId: string;
+  repositoryName: string;
+  repositoryId: string;
+  subjectType: SubjectType;
+}): string => {
+  const base = `repo:${input.gitHubOrgName}@${input.gitHubOrgId}/${input.repositoryName}@${input.repositoryId}`;
+  switch (input.subjectType) {
+    case "repository":
+      return `${base}:*`;
+  }
+};
 
 export type CreateGitHubIamRoleName = (input: CreateGitHubIamRoleNameCommand) => Result<CreatedGitHubIamRoleName, HandlerError>;
 export const createGitHubIamRoleName =
@@ -28,23 +55,39 @@ export const createGitHubIamRoleName =
       );
     }
     const parsedInput = parsedResult.data;
-    if (!config.gitHubOrgNames.includes(parsedInput.gitHubOrgName)) {
-      const message = `GitHub organization "${parsedInput.gitHubOrgName}" is not allowed. Allowed organizations: ${config.gitHubOrgNames.join(", ")}.`;
+    const allowedOrg = findAllowedGitHubOrg(config, parsedInput.gitHubOrgName);
+    if (!allowedOrg) {
+      const message = `GitHub organization "${parsedInput.gitHubOrgName}" is not allowed. Allowed organizations: ${config.gitHubOrgs
+        .map((org) => org.name)
+        .join(", ")}.`;
       return err(new HandlerError(message, "BAD_REQUEST", message));
     }
-    const iamRoleName = `${config.roleNamePrefix}-github-${parsedInput.gitHubOrgName}-${parsedInput.repositoryName}`;
+    const baseRoleName = `${config.roleNamePrefix}-github-${parsedInput.gitHubOrgName}-${parsedInput.repositoryName}`;
+    const iamRoleName = parsedInput.roleSuffix ? `${baseRoleName}-${parsedInput.roleSuffix}` : baseRoleName;
     if (iamRoleName.length > 64) {
       return err(
         new HandlerError(
           `Failed to create role name. ${iamRoleName} is over 64 character.`,
           "BAD_REQUEST",
-          `Failed to create role name. ${iamRoleName} is over 64 character. Please use a shorter repository name or a GitHub organization with a shorter name.`
+          `Failed to create role name. ${iamRoleName} is over 64 character. Please use a shorter repository name, role suffix, or a GitHub organization with a shorter name.`
         )
       );
     }
+    const subject = buildGitHubSubjectClaim({
+      gitHubOrgName: parsedInput.gitHubOrgName,
+      gitHubOrgId: allowedOrg.id,
+      repositoryName: parsedInput.repositoryName,
+      repositoryId: parsedInput.repositoryId,
+      subjectType: parsedInput.subjectType,
+    });
     return ok({
       repositoryName: parsedInput.repositoryName,
       gitHubOrgName: parsedInput.gitHubOrgName,
+      repositoryId: parsedInput.repositoryId,
+      gitHubOrgId: allowedOrg.id,
+      roleSuffix: parsedInput.roleSuffix,
+      subjectType: parsedInput.subjectType,
+      subject,
       iamRoleName,
     });
   };
@@ -77,7 +120,7 @@ export const createGitHubIamRoleInAws =
           Action: "sts:AssumeRoleWithWebIdentity",
           Condition: {
             StringLike: {
-              "token.actions.githubusercontent.com:sub": `repo:${parsedInput.gitHubOrgName}/${parsedInput.repositoryName}:*`,
+              "token.actions.githubusercontent.com:sub": parsedInput.subject,
             },
           },
         },

--- a/catalogs/iam-role/src/events/resource/gitHubIamRole.unit.test.ts
+++ b/catalogs/iam-role/src/events/resource/gitHubIamRole.unit.test.ts
@@ -1,12 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { CreateRoleCommand, IAMClient } from "@aws-sdk/client-iam";
+import { createLogger } from "@stamp-lib/stamp-logger";
+import { describe, expect, it, vi } from "vitest";
 import { IamRoleCatalogConfig } from "../../config";
-import { createGitHubIamRoleName } from "./gitHubIamRole";
+import { buildGitHubSubjectClaim, createGitHubIamRoleInAws, createGitHubIamRoleName } from "./gitHubIamRole";
 
 const baseConfig: IamRoleCatalogConfig = IamRoleCatalogConfig.parse({
   region: "us-west-2",
   iamRoleFactoryAccountId: "123456789012",
   iamRoleFactoryAccountRoleArn: "arn:aws:iam::123456789012:role/factory",
-  gitHubOrgNames: ["org-a", "org-b"],
+  gitHubOrgs: [
+    { name: "org-a", id: "111" },
+    { name: "org-b", id: "222" },
+  ],
   policyNamePrefix: "stamp",
   roleNamePrefix: "stamp",
   awsAccountResourceTableName: "t-aws",
@@ -15,21 +20,77 @@ const baseConfig: IamRoleCatalogConfig = IamRoleCatalogConfig.parse({
   jumpIamRoleResourceTableName: "t-jump",
 });
 
+describe("buildGitHubSubjectClaim", () => {
+  it("builds the immutable whole-repository subject", () => {
+    const subject = buildGitHubSubjectClaim({
+      gitHubOrgName: "org-a",
+      gitHubOrgId: "111",
+      repositoryName: "my-repo",
+      repositoryId: "12345",
+      subjectType: "repository",
+    });
+    expect(subject).toBe("repo:org-a@111/my-repo@12345:*");
+  });
+});
+
 describe("createGitHubIamRoleName (multi-org)", () => {
-  it("creates the role name using the requested allowed org", () => {
-    const result = createGitHubIamRoleName(baseConfig)({ repositoryName: "my-repo", gitHubOrgName: "org-b" });
+  it("creates the role name using the requested allowed org and resolves the org id from config", () => {
+    const result = createGitHubIamRoleName(baseConfig)({
+      repositoryName: "my-repo",
+      gitHubOrgName: "org-b",
+      repositoryId: "12345",
+      subjectType: "repository",
+    });
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       expect(result.value).toEqual({
         repositoryName: "my-repo",
         gitHubOrgName: "org-b",
+        repositoryId: "12345",
+        gitHubOrgId: "222",
+        roleSuffix: undefined,
+        subjectType: "repository",
+        subject: "repo:org-b@222/my-repo@12345:*",
         iamRoleName: "stamp-github-org-b-my-repo",
       });
     }
   });
 
+  it("defaults subjectType to repository when omitted", () => {
+    const result = createGitHubIamRoleName(baseConfig)({
+      repositoryName: "my-repo",
+      gitHubOrgName: "org-a",
+      repositoryId: "12345",
+    } as Parameters<ReturnType<typeof createGitHubIamRoleName>>[0]);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.subjectType).toBe("repository");
+      expect(result.value.subject).toBe("repo:org-a@111/my-repo@12345:*");
+    }
+  });
+
+  it("appends the role suffix to the role name", () => {
+    const result = createGitHubIamRoleName(baseConfig)({
+      repositoryName: "my-repo",
+      gitHubOrgName: "org-a",
+      repositoryId: "12345",
+      roleSuffix: "prod-deploy",
+      subjectType: "repository",
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.iamRoleName).toBe("stamp-github-org-a-my-repo-prod-deploy");
+      expect(result.value.roleSuffix).toBe("prod-deploy");
+    }
+  });
+
   it("rejects an org that is not on the allow-list", () => {
-    const result = createGitHubIamRoleName(baseConfig)({ repositoryName: "my-repo", gitHubOrgName: "not-allowed" });
+    const result = createGitHubIamRoleName(baseConfig)({
+      repositoryName: "my-repo",
+      gitHubOrgName: "not-allowed",
+      repositoryId: "12345",
+      subjectType: "repository",
+    });
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error.userMessage).toContain("not allowed");
@@ -39,12 +100,43 @@ describe("createGitHubIamRoleName (multi-org)", () => {
   });
 
   it("rejects when the resulting role name would exceed 64 characters", () => {
-    const result = createGitHubIamRoleName(baseConfig)({ repositoryName: "r".repeat(60), gitHubOrgName: "org-a" });
+    const result = createGitHubIamRoleName(baseConfig)({
+      repositoryName: "r".repeat(60),
+      gitHubOrgName: "org-a",
+      repositoryId: "12345",
+      subjectType: "repository",
+    });
     expect(result.isErr()).toBe(true);
   });
 
+  it("rejects when the role name exceeds 64 characters only because of the suffix", () => {
+    // "stamp-github-org-a-" (19) + repo (40) = 59 chars: fits without a
+    // suffix, exceeds 64 with "-suffix1" appended.
+    const repositoryName = "r".repeat(40);
+    const withoutSuffix = createGitHubIamRoleName(baseConfig)({
+      repositoryName,
+      gitHubOrgName: "org-a",
+      repositoryId: "12345",
+      subjectType: "repository",
+    });
+    expect(withoutSuffix.isOk()).toBe(true);
+    const withSuffix = createGitHubIamRoleName(baseConfig)({
+      repositoryName,
+      gitHubOrgName: "org-a",
+      repositoryId: "12345",
+      roleSuffix: "suffix1",
+      subjectType: "repository",
+    });
+    expect(withSuffix.isErr()).toBe(true);
+  });
+
   it("rejects empty repositoryName via runtime schema validation", () => {
-    const result = createGitHubIamRoleName(baseConfig)({ repositoryName: "", gitHubOrgName: "org-a" });
+    const result = createGitHubIamRoleName(baseConfig)({
+      repositoryName: "",
+      gitHubOrgName: "org-a",
+      repositoryId: "12345",
+      subjectType: "repository",
+    });
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error.userMessage).toContain("Failed to parse input");
@@ -52,7 +144,91 @@ describe("createGitHubIamRoleName (multi-org)", () => {
   });
 
   it("rejects empty gitHubOrgName via runtime schema validation", () => {
-    const result = createGitHubIamRoleName(baseConfig)({ repositoryName: "my-repo", gitHubOrgName: "" });
+    const result = createGitHubIamRoleName(baseConfig)({
+      repositoryName: "my-repo",
+      gitHubOrgName: "",
+      repositoryId: "12345",
+      subjectType: "repository",
+    });
     expect(result.isErr()).toBe(true);
+  });
+
+  it.each(["", "abc", "12a"])("rejects a non-numeric repositoryId (%j) via runtime schema validation", (repositoryId) => {
+    const result = createGitHubIamRoleName(baseConfig)({
+      repositoryName: "my-repo",
+      gitHubOrgName: "org-a",
+      repositoryId,
+      subjectType: "repository",
+    });
+    expect(result.isErr()).toBe(true);
+  });
+
+  it.each(["-bad", "bad-", "has space", "has_underscore", "a".repeat(33)])("rejects an invalid roleSuffix (%j)", (roleSuffix) => {
+    const result = createGitHubIamRoleName(baseConfig)({
+      repositoryName: "my-repo",
+      gitHubOrgName: "org-a",
+      repositoryId: "12345",
+      roleSuffix,
+      subjectType: "repository",
+    });
+    expect(result.isErr()).toBe(true);
+  });
+});
+
+describe("createGitHubIamRoleInAws (trust policy shape)", () => {
+  const logger = createLogger("FATAL", { moduleName: "iam-role-test" });
+
+  it("writes the immutable-claims sub condition to the assume-role policy", async () => {
+    const send = vi.fn().mockResolvedValue({ Role: { Arn: "arn:aws:iam::123456789012:role/stamp-github-org-a-my-repo" } });
+    const iamClient = { send } as unknown as IAMClient;
+
+    const result = await createGitHubIamRoleInAws(
+      logger,
+      baseConfig,
+      iamClient
+    )({
+      repositoryName: "my-repo",
+      gitHubOrgName: "org-a",
+      repositoryId: "12345",
+      gitHubOrgId: "111",
+      subjectType: "repository",
+      subject: "repo:org-a@111/my-repo@12345:*",
+      iamRoleName: "stamp-github-org-a-my-repo",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(send).toHaveBeenCalledTimes(1);
+    const command = send.mock.calls[0][0] as CreateRoleCommand;
+    expect(command).toBeInstanceOf(CreateRoleCommand);
+    expect(command.input.RoleName).toBe("stamp-github-org-a-my-repo");
+
+    const policy = JSON.parse(command.input.AssumeRolePolicyDocument as string);
+    expect(policy).toEqual({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Sid: "",
+          Effect: "Allow",
+          Principal: {
+            Federated: "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com",
+          },
+          Action: "sts:AssumeRoleWithWebIdentity",
+          Condition: {
+            StringLike: {
+              "token.actions.githubusercontent.com:sub": "repo:org-a@111/my-repo@12345:*",
+            },
+          },
+        },
+      ],
+    });
+    // The sub condition must be a single string in the new immutable format —
+    // no legacy `repo:org/repo:*` fallback.
+    const sub = policy.Statement[0].Condition.StringLike["token.actions.githubusercontent.com:sub"];
+    expect(typeof sub).toBe("string");
+
+    if (result.isOk()) {
+      expect(result.value.iamRoleArn).toBe("arn:aws:iam::123456789012:role/stamp-github-org-a-my-repo");
+      expect(result.value.subject).toBe("repo:org-a@111/my-repo@12345:*");
+    }
   });
 });

--- a/catalogs/iam-role/src/events/resource/jumpIamRole.test.ts
+++ b/catalogs/iam-role/src/events/resource/jumpIamRole.test.ts
@@ -22,7 +22,7 @@ const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: "test-arn",
-  gitHubOrgNames: [githubOrgName],
+  gitHubOrgs: [{ name: githubOrgName, id: "1234567" }],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   awsAccountResourceTableName: `${process.env.IAM_ROLE_DYNAMO_TABLE_PREFIX}-iam-role-AWSAccountResource`,

--- a/catalogs/iam-role/src/handlers/awsAccountResource.test.ts
+++ b/catalogs/iam-role/src/handlers/awsAccountResource.test.ts
@@ -21,7 +21,7 @@ const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: `arn:aws:iam::${iamRoleFactoryAccountId}:role/stamp-execute-role`,
-  gitHubOrgNames: [githubOrgName],
+  gitHubOrgs: [{ name: githubOrgName, id: "1234567" }],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   awsAccountResourceTableName: `${process.env.IAM_ROLE_DYNAMO_TABLE_PREFIX}-iam-role-AWSAccountResource`,

--- a/catalogs/iam-role/src/handlers/gitHubIamRoleResource.test.ts
+++ b/catalogs/iam-role/src/handlers/gitHubIamRoleResource.test.ts
@@ -16,12 +16,19 @@ const resourceTypeId = "iam-role-aws-account";
 const repositoryName = "test-repository";
 const githubOrgName = process.env.GITHUB_ORG_NAME!;
 const repositoryResourceId = `${githubOrgName}/${repositoryName}`;
+// Fixed fixtures: IAM never validates sub-claim contents against GitHub, so
+// any numeric strings work for integration tests.
+const gitHubOrgId = "1234567";
+const repositoryId = "9876543";
+const expectedSubject = `repo:${githubOrgName}@${gitHubOrgId}/${repositoryName}@${repositoryId}:*`;
+const roleSuffix = "it-suffix";
+const suffixedResourceId = `${githubOrgName}/${repositoryName}/${roleSuffix}`;
 
 const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: `arn:aws:iam::${iamRoleFactoryAccountId}:role/stamp-execute-role`,
-  gitHubOrgNames: [githubOrgName],
+  gitHubOrgs: [{ name: githubOrgName, id: gitHubOrgId }],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   gitHubIamRoleResourceTableName: `${process.env.IAM_ROLE_DYNAMO_TABLE_PREFIX}-iam-role-GitHubIamRoleResource`,
@@ -34,19 +41,15 @@ const gitHubIamRoleResource = createGitHubIamRoleResourceHandler(config);
 
 describe("Testing gitHubIamRoleResource", () => {
   beforeAll(async () => {
-    const input: DeleteResourceInput = {
-      resourceTypeId: resourceTypeId,
-      resourceId: repositoryResourceId,
-    };
-    await gitHubIamRoleResource.deleteResource(input);
+    for (const resourceId of [repositoryResourceId, suffixedResourceId]) {
+      await gitHubIamRoleResource.deleteResource({ resourceTypeId, resourceId });
+    }
   });
 
   afterAll(async () => {
-    const input: DeleteResourceInput = {
-      resourceTypeId: resourceTypeId,
-      resourceId: repositoryResourceId,
-    };
-    await gitHubIamRoleResource.deleteResource(input);
+    for (const resourceId of [repositoryResourceId, suffixedResourceId]) {
+      await gitHubIamRoleResource.deleteResource({ resourceTypeId, resourceId });
+    }
   });
 
   describe("createResourceHandler", () => {
@@ -56,12 +59,16 @@ describe("Testing gitHubIamRoleResource", () => {
         inputParams: {
           repositoryName: repositoryName,
           gitHubOrgName: githubOrgName,
+          repositoryId: repositoryId,
         },
       };
       const expected: ResourceOutput = {
         params: {
           repositoryName: repositoryName,
           gitHubOrgName: githubOrgName,
+          repositoryId: repositoryId,
+          subjectType: "repository",
+          subject: expectedSubject,
           iamRoleArn: expect.any(String),
         },
         name: repositoryResourceId,
@@ -78,6 +85,58 @@ describe("Testing gitHubIamRoleResource", () => {
       if (result2.isErr()) {
         expect(result2.error.userMessage).toContain("already exists");
       }
+    });
+
+    it("creates a second role for the same repository when a roleSuffix is given", async () => {
+      const input: CreateResourceInput = {
+        resourceTypeId: resourceTypeId,
+        inputParams: {
+          repositoryName: repositoryName,
+          gitHubOrgName: githubOrgName,
+          repositoryId: repositoryId,
+          roleSuffix: roleSuffix,
+        },
+      };
+      const expected: ResourceOutput = {
+        params: {
+          repositoryName: repositoryName,
+          gitHubOrgName: githubOrgName,
+          repositoryId: repositoryId,
+          roleSuffix: roleSuffix,
+          subjectType: "repository",
+          subject: expectedSubject,
+          iamRoleArn: expect.any(String),
+        },
+        name: suffixedResourceId,
+        resourceId: suffixedResourceId,
+      };
+      const result = await gitHubIamRoleResource.createResource(input);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value).toEqual(expected);
+      expect(result.value.params.iamRoleArn).toContain(`-${roleSuffix}`);
+
+      // Both roles for the repository can be fetched independently.
+      const suffixed = await gitHubIamRoleResource.getResource({ resourceTypeId, resourceId: suffixedResourceId });
+      if (suffixed.isErr()) {
+        throw suffixed.error;
+      }
+      expect(suffixed.value.isSome()).toBe(true);
+      const unsuffixed = await gitHubIamRoleResource.getResource({ resourceTypeId, resourceId: repositoryResourceId });
+      if (unsuffixed.isErr()) {
+        throw unsuffixed.error;
+      }
+      expect(unsuffixed.value.isSome()).toBe(true);
+
+      // Deleting the suffixed role leaves the base role intact.
+      const deleted = await gitHubIamRoleResource.deleteResource({ resourceTypeId, resourceId: suffixedResourceId });
+      expect(deleted.isOk()).toBe(true);
+      const stillThere = await gitHubIamRoleResource.getResource({ resourceTypeId, resourceId: repositoryResourceId });
+      if (stillThere.isErr()) {
+        throw stillThere.error;
+      }
+      expect(stillThere.value.isSome()).toBe(true);
     });
 
     it("returns failed result if repository name is empty", async () => {
@@ -116,6 +175,9 @@ describe("Testing gitHubIamRoleResource", () => {
         params: {
           repositoryName: repositoryName,
           gitHubOrgName: githubOrgName,
+          repositoryId: repositoryId,
+          subjectType: "repository",
+          subject: expectedSubject,
           iamRoleArn: expect.any(String),
         },
         name: repositoryResourceId,

--- a/catalogs/iam-role/src/handlers/gitHubIamRoleResource.ts
+++ b/catalogs/iam-role/src/handlers/gitHubIamRoleResource.ts
@@ -25,7 +25,7 @@ import {
 import { createGitHubIamRoleInAws, createGitHubIamRoleName, deleteGitHubIamRoleInAws, listGitHubIamRoleAuditItemInAws } from "../events/resource/gitHubIamRole";
 import { listIamRoleAttachedPolicyArns, fetchAllAttachedRolePolicyArns } from "../events/iam-ops/iamRoleManagement";
 import { assumeRoleCredentialProvider } from "../utils/assumeRoleCredentialProvider";
-import { GitHubIamRole, GitHubRepositoryIdField, RoleSuffixField, SubjectTypeField } from "../types/gitHubIamRole";
+import { GitHubIamRole, GitHubOrgNameField, GitHubRepositoryIdField, GitHubRepositoryNameField, RoleSuffixField, SubjectTypeField } from "../types/gitHubIamRole";
 
 /**
  * Resolves the user-facing repository name and GitHub organization for a
@@ -116,8 +116,24 @@ const createResourceHandler =
     if (typeof input.inputParams.gitHubOrgName !== "string" || input.inputParams.gitHubOrgName.trim() === "") {
       return err(new HandlerError("Invalid input parameters(gitHubOrgName)", "BAD_REQUEST", "Invalid input parameters(gitHubOrgName)"));
     }
-    if (!findAllowedGitHubOrg(parsedConfig, input.inputParams.gitHubOrgName)) {
-      const message = `GitHub organization "${input.inputParams.gitHubOrgName}" is not allowed. Allowed organizations: ${parsedConfig.gitHubOrgs
+    // Trim once and use the trimmed values everywhere below — validating the
+    // trimmed value but looking up the raw one would reject padded input for
+    // orgs that are actually allowed. Charset validation matters because both
+    // names are embedded in the compound PK and the OIDC subject claim, where
+    // `/`, `@`, `:` and whitespace act as delimiters.
+    const repositoryName = input.inputParams.repositoryName.trim();
+    const gitHubOrgName = input.inputParams.gitHubOrgName.trim();
+    if (!GitHubRepositoryNameField.safeParse(repositoryName).success) {
+      const message =
+        "Invalid input parameters(repositoryName): must be a bare repository name (alphanumeric characters, hyphens, underscores, and periods only)";
+      return err(new HandlerError(message, "BAD_REQUEST", message));
+    }
+    if (!GitHubOrgNameField.safeParse(gitHubOrgName).success) {
+      const message = "Invalid input parameters(gitHubOrgName): must be a GitHub organization name (alphanumeric characters and hyphens only)";
+      return err(new HandlerError(message, "BAD_REQUEST", message));
+    }
+    if (!findAllowedGitHubOrg(parsedConfig, gitHubOrgName)) {
+      const message = `GitHub organization "${gitHubOrgName}" is not allowed. Allowed organizations: ${parsedConfig.gitHubOrgs
         .map((org) => org.name)
         .join(", ")}.`;
       return err(new HandlerError(message, "BAD_REQUEST", message));
@@ -155,8 +171,6 @@ const createResourceHandler =
     }
     const subjectType = subjectTypeParseResult.data;
 
-    const repositoryName = input.inputParams.repositoryName;
-    const gitHubOrgName = input.inputParams.gitHubOrgName;
     const repositoryId = input.inputParams.repositoryId.trim();
     const pkValue = buildGitHubIamRolePkValue(gitHubOrgName, repositoryName, roleSuffix);
 

--- a/catalogs/iam-role/src/handlers/gitHubIamRoleResource.ts
+++ b/catalogs/iam-role/src/handlers/gitHubIamRoleResource.ts
@@ -14,7 +14,7 @@ import {
 import { createLogger } from "@stamp-lib/stamp-logger";
 import { some, Option, none } from "@stamp-lib/stamp-option";
 import { IAMClient } from "@aws-sdk/client-iam";
-import { IamRoleCatalogConfig } from "../config";
+import { IamRoleCatalogConfig, findAllowedGitHubOrg } from "../config";
 import {
   buildGitHubIamRolePkValue,
   getGitHubIamRoleDBItem,
@@ -25,7 +25,7 @@ import {
 import { createGitHubIamRoleInAws, createGitHubIamRoleName, deleteGitHubIamRoleInAws, listGitHubIamRoleAuditItemInAws } from "../events/resource/gitHubIamRole";
 import { listIamRoleAttachedPolicyArns, fetchAllAttachedRolePolicyArns } from "../events/iam-ops/iamRoleManagement";
 import { assumeRoleCredentialProvider } from "../utils/assumeRoleCredentialProvider";
-import { GitHubIamRole } from "../types/gitHubIamRole";
+import { GitHubIamRole, GitHubRepositoryIdField, RoleSuffixField, SubjectTypeField } from "../types/gitHubIamRole";
 
 /**
  * Resolves the user-facing repository name and GitHub organization for a
@@ -52,15 +52,34 @@ export const buildResourceOutput = (item: GitHubIamRole, config: IamRoleCatalogC
   const display = resolveDisplayFields(item, config);
   // For multi-org records, the user-visible name encodes the org so identically
   // named repositories under different orgs remain distinguishable in selector
-  // UIs that key off `resource.name`. Legacy single-org records keep the bare
-  // repository name to avoid changing how existing resources are displayed.
-  const displayName = display.isLegacy || !display.gitHubOrgName ? display.repositoryName : `${display.gitHubOrgName}/${display.repositoryName}`;
+  // UIs that key off `resource.name`. The role suffix is appended for the same
+  // reason: multiple roles of one repository must stay distinguishable. Legacy
+  // single-org records keep the bare repository name to avoid changing how
+  // existing resources are displayed.
+  const displayName =
+    display.isLegacy || !display.gitHubOrgName
+      ? display.repositoryName
+      : `${display.gitHubOrgName}/${display.repositoryName}${item.roleSuffix ? `/${item.roleSuffix}` : ""}`;
   const params: Record<string, string> = {
     repositoryName: display.repositoryName,
     iamRoleArn: item.iamRoleArn,
   };
   if (display.gitHubOrgName) {
     params.gitHubOrgName = display.gitHubOrgName;
+  }
+  // Immutable-claims era attributes; absent on records created before that
+  // support landed, in which case they are simply omitted from the output.
+  if (item.gitHubRepositoryId) {
+    params.repositoryId = item.gitHubRepositoryId;
+  }
+  if (item.roleSuffix) {
+    params.roleSuffix = item.roleSuffix;
+  }
+  if (item.subjectType) {
+    params.subjectType = item.subjectType;
+  }
+  if (item.subject) {
+    params.subject = item.subject;
   }
   return {
     resourceId: item.repositoryName,
@@ -97,14 +116,49 @@ const createResourceHandler =
     if (typeof input.inputParams.gitHubOrgName !== "string" || input.inputParams.gitHubOrgName.trim() === "") {
       return err(new HandlerError("Invalid input parameters(gitHubOrgName)", "BAD_REQUEST", "Invalid input parameters(gitHubOrgName)"));
     }
-    if (!parsedConfig.gitHubOrgNames.includes(input.inputParams.gitHubOrgName)) {
-      const message = `GitHub organization "${input.inputParams.gitHubOrgName}" is not allowed. Allowed organizations: ${parsedConfig.gitHubOrgNames.join(", ")}.`;
+    if (!findAllowedGitHubOrg(parsedConfig, input.inputParams.gitHubOrgName)) {
+      const message = `GitHub organization "${input.inputParams.gitHubOrgName}" is not allowed. Allowed organizations: ${parsedConfig.gitHubOrgs
+        .map((org) => org.name)
+        .join(", ")}.`;
       return err(new HandlerError(message, "BAD_REQUEST", message));
     }
+    if (typeof input.inputParams.repositoryId !== "string" || !GitHubRepositoryIdField.safeParse(input.inputParams.repositoryId.trim()).success) {
+      const message =
+        "Invalid input parameters(repositoryId): must be the numeric GitHub repository ID (see `GET https://api.github.com/repos/{owner}/{repo}`)";
+      return err(new HandlerError(message, "BAD_REQUEST", message));
+    }
+    // Optional: distinguishes multiple IAM roles for the same repository.
+    // Treat an empty/whitespace value the same as omitted.
+    const rawRoleSuffix = input.inputParams.roleSuffix;
+    if (rawRoleSuffix !== undefined && typeof rawRoleSuffix !== "string") {
+      return err(new HandlerError("Invalid input parameters(roleSuffix)", "BAD_REQUEST", "Invalid input parameters(roleSuffix)"));
+    }
+    const roleSuffix = typeof rawRoleSuffix === "string" && rawRoleSuffix.trim() !== "" ? rawRoleSuffix.trim() : undefined;
+    if (roleSuffix !== undefined && !RoleSuffixField.safeParse(roleSuffix).success) {
+      const message =
+        "Invalid input parameters(roleSuffix): must be 1-32 alphanumeric/hyphen characters, starting and ending with an alphanumeric character";
+      return err(new HandlerError(message, "BAD_REQUEST", message));
+    }
+    // Optional: defaults to "repository" (whole-repo scope). Other subject
+    // types (branch / environment / tag / pull_request) are planned but not
+    // yet supported.
+    const rawSubjectType = input.inputParams.subjectType;
+    if (rawSubjectType !== undefined && typeof rawSubjectType !== "string") {
+      return err(new HandlerError("Invalid input parameters(subjectType)", "BAD_REQUEST", "Invalid input parameters(subjectType)"));
+    }
+    const subjectTypeParseResult = SubjectTypeField.safeParse(
+      typeof rawSubjectType === "string" && rawSubjectType.trim() !== "" ? rawSubjectType.trim() : undefined
+    );
+    if (!subjectTypeParseResult.success) {
+      const message = `Invalid input parameters(subjectType): "${rawSubjectType}" is not yet supported. Supported values: repository (default).`;
+      return err(new HandlerError(message, "BAD_REQUEST", message));
+    }
+    const subjectType = subjectTypeParseResult.data;
 
     const repositoryName = input.inputParams.repositoryName;
     const gitHubOrgName = input.inputParams.gitHubOrgName;
-    const pkValue = buildGitHubIamRolePkValue(gitHubOrgName, repositoryName);
+    const repositoryId = input.inputParams.repositoryId.trim();
+    const pkValue = buildGitHubIamRolePkValue(gitHubOrgName, repositoryName, roleSuffix);
 
     // If it has already been created, an error indicating "already created" will be returned.
     const result = await getGitHubIamRoleDBItem(logger, parsedConfig.gitHubIamRoleResourceTableName, { region: parsedConfig.region })({
@@ -114,7 +168,7 @@ const createResourceHandler =
       return err(new HandlerError(`${result.error}`, "INTERNAL_SERVER_ERROR"));
     }
     if (result.isOk() && result.value.isSome()) {
-      const message = `The GitHub IAM role for ${gitHubOrgName}/${repositoryName} already exists.`;
+      const message = `The GitHub IAM role for ${pkValue} already exists.`;
       return err(new HandlerError(message, "BAD_REQUEST", message));
     }
 
@@ -135,9 +189,10 @@ const createResourceHandler =
         return err(new HandlerError(`${legacyResult.error}`, "INTERNAL_SERVER_ERROR"));
       }
       if (legacyResult.isOk() && legacyResult.value.isSome()) {
-        const prospectiveIamRoleName = `${parsedConfig.roleNamePrefix}-github-${gitHubOrgName}-${repositoryName}`;
+        const baseRoleName = `${parsedConfig.roleNamePrefix}-github-${gitHubOrgName}-${repositoryName}`;
+        const prospectiveIamRoleName = roleSuffix ? `${baseRoleName}-${roleSuffix}` : baseRoleName;
         if (legacyResult.value.value.iamRoleName === prospectiveIamRoleName) {
-          const message = `The GitHub IAM role for ${gitHubOrgName}/${repositoryName} already exists (legacy record).`;
+          const message = `The GitHub IAM role for ${pkValue} already exists (legacy record).`;
           return err(new HandlerError(message, "BAD_REQUEST", message));
         }
       }
@@ -146,6 +201,9 @@ const createResourceHandler =
     const createInput = {
       repositoryName,
       gitHubOrgName,
+      repositoryId,
+      roleSuffix,
+      subjectType,
     };
 
     const iamClient = new IAMClient({

--- a/catalogs/iam-role/src/handlers/gitHubIamRoleResource.unit.test.ts
+++ b/catalogs/iam-role/src/handlers/gitHubIamRoleResource.unit.test.ts
@@ -188,6 +188,45 @@ describe("createResource input validation (short-circuits before any AWS call)",
     }
   });
 
+  it.each(["owner/repo", "repo name", "repo@123", "repo:ref"])("rejects a repositoryName with delimiter characters (%j)", async (badRepositoryName) => {
+    const result = await createResource({
+      ...baseInput,
+      inputParams: { ...baseInput.inputParams, repositoryName: badRepositoryName },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("BAD_REQUEST");
+      expect(result.error.userMessage).toContain("repositoryName");
+    }
+  });
+
+  it.each(["org/a", "org a", "org@123", "org_a"])("rejects a gitHubOrgName with characters GitHub does not allow (%j)", async (badOrgName) => {
+    const result = await createResource({
+      ...baseInput,
+      inputParams: { ...baseInput.inputParams, gitHubOrgName: badOrgName },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("BAD_REQUEST");
+      expect(result.error.userMessage).not.toContain("not allowed");
+    }
+  });
+
+  it("trims a padded gitHubOrgName before the allow-list lookup", async () => {
+    // With a padded-but-allowed org, validation must proceed past the
+    // allow-list check; the invalid repositoryId then short-circuits before
+    // any AWS call, proving the trimmed value was used for the lookup.
+    const result = await createResource({
+      ...baseInput,
+      inputParams: { ...baseInput.inputParams, gitHubOrgName: " org-a ", repositoryId: "not-numeric" },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.userMessage).not.toContain("not allowed");
+      expect(result.error.userMessage).toContain("repositoryId");
+    }
+  });
+
   it("rejects an org that is not on the allow-list, listing allowed org names", async () => {
     const result = await createResource({
       ...baseInput,

--- a/catalogs/iam-role/src/handlers/gitHubIamRoleResource.unit.test.ts
+++ b/catalogs/iam-role/src/handlers/gitHubIamRoleResource.unit.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from "vitest";
 import { IamRoleCatalogConfig } from "../config";
-import { buildResourceOutput, resolveDisplayFields } from "./gitHubIamRoleResource";
+import { buildResourceOutput, createGitHubIamRoleResourceHandler, resolveDisplayFields } from "./gitHubIamRoleResource";
 
 const makeConfig = (overrides: Partial<Record<string, unknown>> = {}): IamRoleCatalogConfig =>
   IamRoleCatalogConfig.parse({
     region: "us-west-2",
     iamRoleFactoryAccountId: "123456789012",
     iamRoleFactoryAccountRoleArn: "arn:aws:iam::123456789012:role/factory",
-    gitHubOrgNames: ["org-a", "org-b"],
+    gitHubOrgs: [
+      { name: "org-a", id: "111" },
+      { name: "org-b", id: "222" },
+    ],
     policyNamePrefix: "stamp",
     roleNamePrefix: "stamp",
     awsAccountResourceTableName: "t-aws",
@@ -19,7 +22,12 @@ const makeConfig = (overrides: Partial<Record<string, unknown>> = {}): IamRoleCa
 
 describe("resolveDisplayFields / buildResourceOutput", () => {
   it("legacy record (no gitHubOrgName attribute) returns undefined org (no silent fallback)", () => {
-    const cfg = makeConfig({ gitHubOrgNames: ["org-b", "org-a"] });
+    const cfg = makeConfig({
+      gitHubOrgs: [
+        { name: "org-b", id: "222" },
+        { name: "org-a", id: "111" },
+      ],
+    });
     const display = resolveDisplayFields(
       { repositoryName: "old-repo", iamRoleName: "x", iamRoleArn: "y", createdAt: "2024-01-01" },
       cfg
@@ -28,7 +36,7 @@ describe("resolveDisplayFields / buildResourceOutput", () => {
   });
 
   it("legacy record exposes bare repo name from the PK without guessing the org", () => {
-    const cfg = makeConfig({ gitHubOrgNames: ["org-a", "org-b"] });
+    const cfg = makeConfig();
     const display = resolveDisplayFields(
       { repositoryName: "old-repo", iamRoleName: "x", iamRoleArn: "y", createdAt: "2024-01-01" },
       cfg
@@ -54,8 +62,8 @@ describe("resolveDisplayFields / buildResourceOutput", () => {
     expect(display).toEqual({ repositoryName: "new-repo", gitHubOrgName: "org-b", isLegacy: false });
   });
 
-  it("buildResourceOutput keeps bare display name for legacy records and omits gitHubOrgName from params", () => {
-    const cfg = makeConfig({ gitHubOrgNames: ["org-a"] });
+  it("buildResourceOutput keeps bare display name for legacy records and omits new params", () => {
+    const cfg = makeConfig({ gitHubOrgs: [{ name: "org-a", id: "111" }] });
     const output = buildResourceOutput(
       { repositoryName: "legacy-repo", iamRoleName: "r", iamRoleArn: "arn", createdAt: "2024-01-01" },
       cfg
@@ -67,6 +75,8 @@ describe("resolveDisplayFields / buildResourceOutput", () => {
       iamRoleArn: "arn",
     });
     expect(output.params.gitHubOrgName).toBeUndefined();
+    expect(output.params.repositoryId).toBeUndefined();
+    expect(output.params.subject).toBeUndefined();
   });
 
   it("buildResourceOutput uses compound display name for multi-org records (so same repo name across orgs is distinguishable in UI)", () => {
@@ -90,4 +100,131 @@ describe("resolveDisplayFields / buildResourceOutput", () => {
       iamRoleArn: "arn",
     });
   });
+
+  it("buildResourceOutput exposes immutable-claims attributes when present", () => {
+    const cfg = makeConfig();
+    const output = buildResourceOutput(
+      {
+        repositoryName: "org-b/new-repo",
+        gitHubRepositoryName: "new-repo",
+        gitHubOrgName: "org-b",
+        gitHubRepositoryId: "12345",
+        gitHubOrgId: "222",
+        subjectType: "repository",
+        subject: "repo:org-b@222/new-repo@12345:*",
+        iamRoleName: "r",
+        iamRoleArn: "arn",
+        createdAt: "2024-01-01",
+      },
+      cfg
+    );
+    expect(output.params).toEqual({
+      repositoryName: "new-repo",
+      gitHubOrgName: "org-b",
+      repositoryId: "12345",
+      subjectType: "repository",
+      subject: "repo:org-b@222/new-repo@12345:*",
+      iamRoleArn: "arn",
+    });
+  });
+
+  it("buildResourceOutput appends the role suffix to the display name so multiple roles per repo stay distinguishable", () => {
+    const cfg = makeConfig();
+    const output = buildResourceOutput(
+      {
+        repositoryName: "org-b/new-repo/prod-deploy",
+        gitHubRepositoryName: "new-repo",
+        gitHubOrgName: "org-b",
+        gitHubRepositoryId: "12345",
+        gitHubOrgId: "222",
+        roleSuffix: "prod-deploy",
+        subjectType: "repository",
+        subject: "repo:org-b@222/new-repo@12345:*",
+        iamRoleName: "r",
+        iamRoleArn: "arn",
+        createdAt: "2024-01-01",
+      },
+      cfg
+    );
+    expect(output.resourceId).toBe("org-b/new-repo/prod-deploy");
+    expect(output.name).toBe("org-b/new-repo/prod-deploy");
+    expect(output.params.roleSuffix).toBe("prod-deploy");
+  });
+});
+
+describe("createResource input validation (short-circuits before any AWS call)", () => {
+  const cfg = makeConfig();
+  const createResource = createGitHubIamRoleResourceHandler(cfg).createResource;
+  const baseInput = {
+    resourceTypeId: "github-iam-role",
+    inputParams: {
+      gitHubOrgName: "org-a",
+      repositoryName: "my-repo",
+      repositoryId: "12345",
+    },
+  };
+
+  it("rejects a missing repositoryId", async () => {
+    const result = await createResource({
+      ...baseInput,
+      inputParams: { gitHubOrgName: "org-a", repositoryName: "my-repo" },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("BAD_REQUEST");
+      expect(result.error.userMessage).toContain("repositoryId");
+    }
+  });
+
+  it.each(["", "abc", "12a", "1 2"])("rejects a non-numeric repositoryId (%j)", async (repositoryId) => {
+    const result = await createResource({
+      ...baseInput,
+      inputParams: { ...baseInput.inputParams, repositoryId },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("BAD_REQUEST");
+      expect(result.error.userMessage).toContain("repositoryId");
+    }
+  });
+
+  it("rejects an org that is not on the allow-list, listing allowed org names", async () => {
+    const result = await createResource({
+      ...baseInput,
+      inputParams: { ...baseInput.inputParams, gitHubOrgName: "org-c" },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("BAD_REQUEST");
+      expect(result.error.userMessage).toContain("org-a");
+      expect(result.error.userMessage).toContain("org-b");
+    }
+  });
+
+  it.each(["-bad", "bad-", "has space", "a".repeat(33)])("rejects an invalid roleSuffix (%j)", async (roleSuffix) => {
+    const result = await createResource({
+      ...baseInput,
+      inputParams: { ...baseInput.inputParams, roleSuffix },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("BAD_REQUEST");
+      expect(result.error.userMessage).toContain("roleSuffix");
+    }
+  });
+
+  it.each(["branch", "environment", "tag", "pull_request", "bogus"])(
+    "rejects the not-yet-supported subjectType %j",
+    async (subjectType) => {
+      const result = await createResource({
+        ...baseInput,
+        inputParams: { ...baseInput.inputParams, subjectType },
+      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe("BAD_REQUEST");
+        expect(result.error.userMessage).toContain("subjectType");
+      }
+    }
+  );
 });

--- a/catalogs/iam-role/src/handlers/iamRolePromoteRequest.policyGrantLimitScenario.test.ts
+++ b/catalogs/iam-role/src/handlers/iamRolePromoteRequest.policyGrantLimitScenario.test.ts
@@ -28,7 +28,7 @@ const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: `arn:aws:iam::${iamRoleFactoryAccountId}:role/stamp-execute-role`,
-  gitHubOrgNames: [githubOrgName],
+  gitHubOrgs: [{ name: githubOrgName, id: "1234567" }],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   awsAccountResourceTableName: tableNameForAWSAccount,
@@ -106,6 +106,7 @@ describe(
         inputParams: {
           repositoryName: repositoryName,
           gitHubOrgName: githubOrgName,
+          repositoryId: "9876543",
         },
       });
       for (let suffix = 1; suffix <= 11; suffix++) {

--- a/catalogs/iam-role/src/handlers/iamRolePromoteRequest.test.ts
+++ b/catalogs/iam-role/src/handlers/iamRolePromoteRequest.test.ts
@@ -39,7 +39,7 @@ const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: `arn:aws:iam::${iamRoleFactoryAccountId}:role/stamp-execute-role`,
-  gitHubOrgNames: [githubOrgName],
+  gitHubOrgs: [{ name: githubOrgName, id: "1234567" }],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   awsAccountResourceTableName: tableNameForAWSAccount,
@@ -119,6 +119,7 @@ describe("Testing iamRolePromoteRequest", () => {
       inputParams: {
         repositoryName: repositoryName,
         gitHubOrgName: githubOrgName,
+        repositoryId: "9876543",
       },
     });
     await targetIamRoleResourceHandler.createResource({

--- a/catalogs/iam-role/src/handlers/jumpIamRolePromoteRequest.policyGrantLimitScenario.test.ts
+++ b/catalogs/iam-role/src/handlers/jumpIamRolePromoteRequest.policyGrantLimitScenario.test.ts
@@ -27,7 +27,7 @@ const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: `arn:aws:iam::${iamRoleFactoryAccountId}:role/stamp-execute-role`,
-  gitHubOrgNames: [githubOrgName],
+  gitHubOrgs: [{ name: githubOrgName, id: "1234567" }],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   awsAccountResourceTableName: tableNameForAWSAccount,

--- a/catalogs/iam-role/src/handlers/jumpIamRolePromoteRequest.test.ts
+++ b/catalogs/iam-role/src/handlers/jumpIamRolePromoteRequest.test.ts
@@ -39,7 +39,7 @@ const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: `arn:aws:iam::${iamRoleFactoryAccountId}:role/stamp-execute-role`,
-  gitHubOrgNames: [githubOrgName],
+  gitHubOrgs: [{ name: githubOrgName, id: "1234567" }],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   awsAccountResourceTableName: tableNameForAWSAccount,

--- a/catalogs/iam-role/src/handlers/jumpIamRoleResource.test.ts
+++ b/catalogs/iam-role/src/handlers/jumpIamRoleResource.test.ts
@@ -21,7 +21,7 @@ const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: `arn:aws:iam::${iamRoleFactoryAccountId}:role/stamp-execute-role`,
-  gitHubOrgNames: [githubOrgName],
+  gitHubOrgs: [{ name: githubOrgName, id: "1234567" }],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   gitHubIamRoleResourceTableName: `${process.env.IAM_ROLE_DYNAMO_TABLE_PREFIX}-iam-role-GitHubIamRoleResource`,

--- a/catalogs/iam-role/src/handlers/targetIamRoleResource.test.ts
+++ b/catalogs/iam-role/src/handlers/targetIamRoleResource.test.ts
@@ -23,7 +23,7 @@ const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: `arn:aws:iam::${iamRoleFactoryAccountId}:role/stamp-execute-role`,
-  gitHubOrgNames: [githubOrgName],
+  gitHubOrgs: [{ name: githubOrgName, id: "1234567" }],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   gitHubIamRoleResourceTableName: `${process.env.IAM_ROLE_DYNAMO_TABLE_PREFIX}-iam-role-GitHubIamRoleResource`,

--- a/catalogs/iam-role/src/index.ts
+++ b/catalogs/iam-role/src/index.ts
@@ -48,10 +48,17 @@ export function createIamRoleCatalog(iamRoleCatalogConfigInput: IamRoleCatalogCo
     createParams: [
       { type: "string", id: "gitHubOrgName", name: "GitHub Organization", required: true },
       { type: "string", id: "repositoryName", name: "Repository Name", required: true },
+      { type: "string", id: "repositoryId", name: "Repository ID (numeric)", required: true },
+      { type: "string", id: "roleSuffix", name: "Role Suffix (optional, for multiple roles per repository)", required: false },
+      { type: "string", id: "subjectType", name: "Subject Type (optional, default: repository)", required: false },
     ],
     infoParams: [
       { type: "string", id: "gitHubOrgName", name: "GitHub Organization", edit: false },
       { type: "string", id: "repositoryName", name: "Repository Name", edit: false },
+      { type: "string", id: "repositoryId", name: "Repository ID", edit: false },
+      { type: "string", id: "roleSuffix", name: "Role Suffix", edit: false },
+      { type: "string", id: "subjectType", name: "Subject Type", edit: false },
+      { type: "string", id: "subject", name: "OIDC Subject Claim", edit: false },
       { type: "string", id: "iamRoleArn", name: "IAM Role Arn", edit: false },
     ],
     handlers: createGitHubIamRoleResourceHandler(iamRoleCatalogConfig),

--- a/catalogs/iam-role/src/intergration-test/iamRolePromoteRequest.test.ts
+++ b/catalogs/iam-role/src/intergration-test/iamRolePromoteRequest.test.ts
@@ -25,7 +25,7 @@ const config: IamRoleCatalogConfig = {
   region: "us-west-2",
   iamRoleFactoryAccountId: iamRoleFactoryAccountId,
   iamRoleFactoryAccountRoleArn: `arn:aws:iam::${iamRoleFactoryAccountId}:role/stamp-execute-role`,
-  gitHubOrgNames: [githubOrgName],
+  gitHubOrgs: [{ name: githubOrgName, id: "1234567" }],
   policyNamePrefix: "test",
   roleNamePrefix: "test",
   awsAccountResourceTableName: tableNameForAWSAccount,
@@ -154,6 +154,7 @@ describe("Testing iamRolePromoteRequest", () => {
       inputParams: {
         repositoryName: repositoryName,
         gitHubOrgName: githubOrgName,
+        repositoryId: "9876543",
       },
     });
     await targetIamRoleResourceHandler.createResource({
@@ -291,6 +292,7 @@ describe("Testing iamRolePromoteRequest", () => {
           inputParams: {
             repositoryName: repositoryName2,
             gitHubOrgName: githubOrgName,
+            repositoryId: "9876543",
           },
         });
         await targetIamRoleResourceHandler.createResource({

--- a/catalogs/iam-role/src/types/gitHubIamRole.ts
+++ b/catalogs/iam-role/src/types/gitHubIamRole.ts
@@ -12,13 +12,53 @@ const GitHubRepositoryNameField = z.string().min(1);
  */
 const GitHubOrgNameField = z.string().min(1);
 
+/**
+ * Immutable numeric GitHub repository ID, as a decimal string (int64-safe).
+ * Required for the immutable OIDC subject claim format
+ * `repo:ORG@ORG_ID/REPO@REPO_ID:...`. Obtain it via
+ * `GET https://api.github.com/repos/{owner}/{repo}` (`id` field).
+ */
+export const GitHubRepositoryIdField = z.string().regex(/^[0-9]+$/, "GitHub repository ID must be a numeric string");
+
+/** Immutable numeric GitHub organization ID, as a decimal string. */
+export const GitHubOrgIdField = z.string().regex(/^[0-9]+$/, "GitHub organization ID must be a numeric string");
+
+/**
+ * Optional user-chosen suffix that distinguishes multiple IAM roles for the
+ * same repository. It becomes part of both the IAM role name and the
+ * resourceId, so it must be filesystem/IAM-safe. When omitted, the role name
+ * and resourceId keep the pre-suffix single-role format, which lets existing
+ * roles be deleted and recreated under the same name.
+ */
+export const RoleSuffixField = z
+  .string()
+  .regex(/^[a-zA-Z0-9]([a-zA-Z0-9-]{0,30}[a-zA-Z0-9])?$/, "roleSuffix must be 1-32 alphanumeric/hyphen characters, starting and ending alphanumeric");
+
+/**
+ * Scope of the OIDC subject claim condition. Only `repository` (whole-repo,
+ * `repo:ORG@ID/REPO@ID:*`) is supported today; branch / environment / tag /
+ * pull_request scoping is planned as a follow-up.
+ */
+export const SubjectTypeField = z.enum(["repository"]).default("repository");
+export type SubjectType = z.infer<typeof SubjectTypeField>;
+
 export const CreateGitHubIamRoleNameCommand = z.object({
   repositoryName: GitHubRepositoryNameField,
   gitHubOrgName: GitHubOrgNameField,
+  repositoryId: GitHubRepositoryIdField,
+  roleSuffix: RoleSuffixField.optional(),
+  subjectType: SubjectTypeField,
 });
 export type CreateGitHubIamRoleNameCommand = z.infer<typeof CreateGitHubIamRoleNameCommand>;
 
-export const CreatedGitHubIamRoleName = CreateGitHubIamRoleNameCommand.merge(z.object({ iamRoleName: z.string() }));
+export const CreatedGitHubIamRoleName = CreateGitHubIamRoleNameCommand.merge(
+  z.object({
+    iamRoleName: z.string(),
+    gitHubOrgId: GitHubOrgIdField,
+    /** Fully assembled OIDC subject claim condition written to the trust policy. */
+    subject: z.string().min(1),
+  })
+);
 export type CreatedGitHubIamRoleName = z.infer<typeof CreatedGitHubIamRoleName>;
 
 export const CreateGitHubIamRoleCommand = CreatedGitHubIamRoleName;
@@ -53,6 +93,30 @@ export const GitHubIamRole = z.object({
     .optional()
     .transform((v) => (v ? v : undefined)),
   gitHubOrgName: z
+    .string()
+    .optional()
+    .transform((v) => (v ? v : undefined)),
+  // Immutable-claims era attributes. Absent on records created before this
+  // support landed (including multi-org records) — same leniency as above.
+  gitHubRepositoryId: z
+    .string()
+    .optional()
+    .transform((v) => (v ? v : undefined)),
+  gitHubOrgId: z
+    .string()
+    .optional()
+    .transform((v) => (v ? v : undefined)),
+  roleSuffix: z
+    .string()
+    .optional()
+    .transform((v) => (v ? v : undefined)),
+  subjectType: z
+    .string()
+    .optional()
+    .transform((v) => (v ? v : undefined)),
+  // The exact OIDC subject condition written to the trust policy, persisted
+  // for auditability (the trust policy itself is never updated after create).
+  subject: z
     .string()
     .optional()
     .transform((v) => (v ? v : undefined)),

--- a/catalogs/iam-role/src/types/gitHubIamRole.ts
+++ b/catalogs/iam-role/src/types/gitHubIamRole.ts
@@ -2,15 +2,24 @@ import { z } from "zod";
 
 /**
  * Bare GitHub repository name (without org prefix). This is what the user
- * enters in the create form and what we render in the UI. Must be non-empty.
+ * enters in the create form and what we render in the UI. Restricted to the
+ * characters GitHub itself allows in repository names — in particular `/`,
+ * `@`, `:` and whitespace are rejected because the name is embedded in both
+ * the compound DynamoDB PK (`org/repo[/suffix]`) and the OIDC subject claim,
+ * where those characters act as delimiters.
  */
-const GitHubRepositoryNameField = z.string().min(1);
+export const GitHubRepositoryNameField = z
+  .string()
+  .regex(/^[a-zA-Z0-9_.-]+$/, "GitHub repository name may only contain alphanumeric characters, hyphens, underscores, and periods");
 
 /**
  * GitHub organization name. New resources require it; persisted records
  * created before multi-org support may not have it (handled by the read path).
+ * Same delimiter-safety rationale as the repository name.
  */
-const GitHubOrgNameField = z.string().min(1);
+export const GitHubOrgNameField = z
+  .string()
+  .regex(/^[a-zA-Z0-9-]+$/, "GitHub organization name may only contain alphanumeric characters and hyphens");
 
 /**
  * Immutable numeric GitHub repository ID, as a decimal string (int64-safe).


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### 🎉 Reason for this change

GitHub is rolling out [immutable subject claims for GitHub Actions OIDC tokens](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/): the `sub` claim now embeds immutable numeric IDs (`repo:ORG@ORG_ID/REPO@REPO_ID:ref:...`). Since **2026-07-15**, all newly created, renamed, or transferred repositories on github.com emit this format unconditionally.

The trust policy this catalog generates matched only the legacy `repo:ORG/REPO:*` format, so **IAM roles created for new repositories can no longer be assumed**. This PR fixes that with the whole-repository scope; stricter scopes (branch / environment / tag / pull_request) are reserved for a follow-up PR.

While a trust policy can only be "updated" by deleting and recreating the role, this PR also adds support for **multiple IAM roles per repository** via an optional role suffix.

### 🔀 Description of changes

**Config (BREAKING)**

`gitHubOrgNames: string[]` is replaced by `gitHubOrgs: { name, id }[]` — each allow-list entry now carries the immutable numeric organization ID (as a decimal string) needed for the new sub format. Duplicate names are rejected because they would make the name→ID lookup ambiguous.

```ts
gitHubOrgs: [{ name: "my-org", id: "1234567" }]
```

**Resource create params**

| param | required | description |
| --- | --- | --- |
| `repositoryId` | ✓ | Immutable numeric repository ID (`GET /repos/{owner}/{repo}` → `id`) |
| `roleSuffix` | – | 1-32 chars `[a-zA-Z0-9-]`; enables multiple IAM roles per repository |
| `subjectType` | – | Defaults to `repository`; other values are rejected as not yet supported |

**Trust policy**

The sub condition now uses the immutable format only (single string, no legacy fallback):

```json
"token.actions.githubusercontent.com:sub": "repo:my-org@1234567/my-repo@9876543:*"
```

**Design decisions**

- The org ID lives in config (orgs are few and fixed) while the repository ID is user input; no GitHub API client is introduced. A mistyped `repositoryId` fails closed (the role can never be assumed) — documented in the README.
- With `roleSuffix`, the IAM role name becomes `${prefix}-github-${org}-${repo}-${suffix}` and the resourceId `${org}/${repo}/${suffix}`. The suffix is deliberately part of the role name so the `IamRoleNameIndex` GSI reverse lookup stays unambiguous. Omitting the suffix keeps the existing naming, so existing roles can be migrated by delete + same-name recreate (no workflow ARN changes).
- New DynamoDB attributes `gitHubRepositoryId` / `gitHubOrgId` / `roleSuffix` / `subjectType` / `subject` (the persisted `subject` records the exact condition written to the trust policy for auditability). Legacy records without them remain readable; no table schema change.
- `createGitHubIamRoleDBItem` now uses a conditional put (`attribute_not_exists`) so a concurrent duplicate create fails instead of silently overwriting.
- Roles created before this change keep their legacy-format trust policy and are **not** migrated automatically (`updateResource` remains unimplemented); migration steps are documented in the README.
- No version bump in this PR (lerna fixed-mode); flagged as breaking for the next release notes.

### 🖨️ Description of how you validated changes

- `npm run build` / `tsc --noEmit` pass (the config rename is fully type-checked across all call sites).
- 54 pure unit tests pass, including a **new trust-policy JSON assertion** (captures `CreateRoleCommand` via a stubbed IAM client and asserts the full statement — the policy shape was previously untested), config validation, handler input validation, and 64-char role-name boundaries with suffixes.
- Full test suite (unit + integration) run against a test AWS account: **22 files / 304 tests passed**. Integration coverage includes IAM accepting the new-format trust policy, the DynamoDB conditional put (duplicate create now fails instead of overwriting), and a new scenario creating two roles for the same repository (with/without roleSuffix) and deleting them independently. Fixtures use fixed numeric IDs — IAM/DynamoDB never validate sub contents against GitHub, so no new env vars are needed.

### 👀 Points to be checked especially by reviewers (if any)

- The trust policy intentionally matches **only** the new immutable format: tokens from repositories still on the legacy sub format will not match newly created roles (the repository must be opted in, or created/renamed after 2026-07-15). Please confirm this all-new-format policy is acceptable operationally.
- The `gitHubOrgs` config rename is a hard break for deployments already on v0.9.0 multi-org config.
- The `roleSuffix` charset/length rule (`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,30}[a-zA-Z0-9])?$`) and its interaction with the 64-char IAM role name limit.

### 🔗 Related links

- https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/
- #93 (multi-org allow-list support this builds on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
