### PR TITLE
fix(iam-role): remove unused config parameter from display helpers

### DIFF
--- a/catalogs/iam-role/src/handlers/gitHubIamRoleResource.ts
+++ b/catalogs/iam-role/src/handlers/gitHubIamRoleResource.ts
@@ -36,10 +36,7 @@ import { GitHubIamRole, GitHubOrgNameField, GitHubRepositoryIdField, GitHubRepos
  * `undefined` and downstream callers must handle the missing value
  * explicitly.
  */
-export const resolveDisplayFields = (
-  item: GitHubIamRole,
-  _config: IamRoleCatalogConfig
-): { repositoryName: string; gitHubOrgName: string | undefined; isLegacy: boolean } => {
+export const resolveDisplayFields = (item: GitHubIamRole): { repositoryName: string; gitHubOrgName: string | undefined; isLegacy: boolean } => {
   const isLegacy = !item.gitHubOrgName;
   return {
     repositoryName: item.gitHubRepositoryName ?? item.repositoryName,
@@ -48,8 +45,8 @@ export const resolveDisplayFields = (
   };
 };
 
-export const buildResourceOutput = (item: GitHubIamRole, config: IamRoleCatalogConfig): ResourceOutput => {
-  const display = resolveDisplayFields(item, config);
+export const buildResourceOutput = (item: GitHubIamRole): ResourceOutput => {
+  const display = resolveDisplayFields(item);
   // For multi-org records, the user-visible name encodes the org so identically
   // named repositories under different orgs remain distinguishable in selector
   // UIs that key off `resource.name`. The role suffix is appended for the same
@@ -228,7 +225,7 @@ const createResourceHandler =
     return await createGitHubIamRoleName(parsedConfig)(createInput)
       .asyncAndThen(createGitHubIamRoleInAws(logger, parsedConfig, iamClient))
       .andThen(createGitHubIamRoleDBItem(logger, parsedConfig.gitHubIamRoleResourceTableName, { region: parsedConfig.region }))
-      .map((persisted) => buildResourceOutput(persisted, parsedConfig));
+      .map((persisted) => buildResourceOutput(persisted));
   };
 
 const deleteResourceHandler =
@@ -275,7 +272,7 @@ const getResourceHandler =
       if (result.isNone()) {
         return none;
       } else {
-        return some(buildResourceOutput(result.value, parsedConfig));
+        return some(buildResourceOutput(result.value));
       }
     });
   };
@@ -294,7 +291,7 @@ const listResourcesHandler =
 
     return await listGitHubIamRoleDBItem(logger, parsedConfig.gitHubIamRoleResourceTableName, { region: parsedConfig.region })(listInput).map((result) => {
       return {
-        resources: result.items.map((item) => buildResourceOutput(item, parsedConfig)),
+        resources: result.items.map((item) => buildResourceOutput(item)),
         nextToken: result.nextToken,
       };
     });

--- a/catalogs/iam-role/src/handlers/gitHubIamRoleResource.unit.test.ts
+++ b/catalogs/iam-role/src/handlers/gitHubIamRoleResource.unit.test.ts
@@ -22,52 +22,31 @@ const makeConfig = (overrides: Partial<Record<string, unknown>> = {}): IamRoleCa
 
 describe("resolveDisplayFields / buildResourceOutput", () => {
   it("legacy record (no gitHubOrgName attribute) returns undefined org (no silent fallback)", () => {
-    const cfg = makeConfig({
-      gitHubOrgs: [
-        { name: "org-b", id: "222" },
-        { name: "org-a", id: "111" },
-      ],
-    });
-    const display = resolveDisplayFields(
-      { repositoryName: "old-repo", iamRoleName: "x", iamRoleArn: "y", createdAt: "2024-01-01" },
-      cfg
-    );
+    const display = resolveDisplayFields({ repositoryName: "old-repo", iamRoleName: "x", iamRoleArn: "y", createdAt: "2024-01-01" });
     expect(display).toEqual({ repositoryName: "old-repo", gitHubOrgName: undefined, isLegacy: true });
   });
 
   it("legacy record exposes bare repo name from the PK without guessing the org", () => {
-    const cfg = makeConfig();
-    const display = resolveDisplayFields(
-      { repositoryName: "old-repo", iamRoleName: "x", iamRoleArn: "y", createdAt: "2024-01-01" },
-      cfg
-    );
+    const display = resolveDisplayFields({ repositoryName: "old-repo", iamRoleName: "x", iamRoleArn: "y", createdAt: "2024-01-01" });
     expect(display.gitHubOrgName).toBeUndefined();
     expect(display.repositoryName).toBe("old-repo");
     expect(display.isLegacy).toBe(true);
   });
 
   it("compound record exposes bare repo name and explicit org", () => {
-    const cfg = makeConfig();
-    const display = resolveDisplayFields(
-      {
-        repositoryName: "org-b/new-repo",
-        gitHubRepositoryName: "new-repo",
-        gitHubOrgName: "org-b",
-        iamRoleName: "x",
-        iamRoleArn: "y",
-        createdAt: "2024-01-01",
-      },
-      cfg
-    );
+    const display = resolveDisplayFields({
+      repositoryName: "org-b/new-repo",
+      gitHubRepositoryName: "new-repo",
+      gitHubOrgName: "org-b",
+      iamRoleName: "x",
+      iamRoleArn: "y",
+      createdAt: "2024-01-01",
+    });
     expect(display).toEqual({ repositoryName: "new-repo", gitHubOrgName: "org-b", isLegacy: false });
   });
 
   it("buildResourceOutput keeps bare display name for legacy records and omits new params", () => {
-    const cfg = makeConfig({ gitHubOrgs: [{ name: "org-a", id: "111" }] });
-    const output = buildResourceOutput(
-      { repositoryName: "legacy-repo", iamRoleName: "r", iamRoleArn: "arn", createdAt: "2024-01-01" },
-      cfg
-    );
+    const output = buildResourceOutput({ repositoryName: "legacy-repo", iamRoleName: "r", iamRoleArn: "arn", createdAt: "2024-01-01" });
     expect(output.resourceId).toBe("legacy-repo");
     expect(output.name).toBe("legacy-repo");
     expect(output.params).toEqual({
@@ -80,18 +59,14 @@ describe("resolveDisplayFields / buildResourceOutput", () => {
   });
 
   it("buildResourceOutput uses compound display name for multi-org records (so same repo name across orgs is distinguishable in UI)", () => {
-    const cfg = makeConfig();
-    const output = buildResourceOutput(
-      {
-        repositoryName: "org-b/shared-repo",
-        gitHubRepositoryName: "shared-repo",
-        gitHubOrgName: "org-b",
-        iamRoleName: "r",
-        iamRoleArn: "arn",
-        createdAt: "2024-01-01",
-      },
-      cfg
-    );
+    const output = buildResourceOutput({
+      repositoryName: "org-b/shared-repo",
+      gitHubRepositoryName: "shared-repo",
+      gitHubOrgName: "org-b",
+      iamRoleName: "r",
+      iamRoleArn: "arn",
+      createdAt: "2024-01-01",
+    });
     expect(output.resourceId).toBe("org-b/shared-repo");
     expect(output.name).toBe("org-b/shared-repo");
     expect(output.params).toEqual({
@@ -102,22 +77,18 @@ describe("resolveDisplayFields / buildResourceOutput", () => {
   });
 
   it("buildResourceOutput exposes immutable-claims attributes when present", () => {
-    const cfg = makeConfig();
-    const output = buildResourceOutput(
-      {
-        repositoryName: "org-b/new-repo",
-        gitHubRepositoryName: "new-repo",
-        gitHubOrgName: "org-b",
-        gitHubRepositoryId: "12345",
-        gitHubOrgId: "222",
-        subjectType: "repository",
-        subject: "repo:org-b@222/new-repo@12345:*",
-        iamRoleName: "r",
-        iamRoleArn: "arn",
-        createdAt: "2024-01-01",
-      },
-      cfg
-    );
+    const output = buildResourceOutput({
+      repositoryName: "org-b/new-repo",
+      gitHubRepositoryName: "new-repo",
+      gitHubOrgName: "org-b",
+      gitHubRepositoryId: "12345",
+      gitHubOrgId: "222",
+      subjectType: "repository",
+      subject: "repo:org-b@222/new-repo@12345:*",
+      iamRoleName: "r",
+      iamRoleArn: "arn",
+      createdAt: "2024-01-01",
+    });
     expect(output.params).toEqual({
       repositoryName: "new-repo",
       gitHubOrgName: "org-b",
@@ -129,23 +100,19 @@ describe("resolveDisplayFields / buildResourceOutput", () => {
   });
 
   it("buildResourceOutput appends the role suffix to the display name so multiple roles per repo stay distinguishable", () => {
-    const cfg = makeConfig();
-    const output = buildResourceOutput(
-      {
-        repositoryName: "org-b/new-repo/prod-deploy",
-        gitHubRepositoryName: "new-repo",
-        gitHubOrgName: "org-b",
-        gitHubRepositoryId: "12345",
-        gitHubOrgId: "222",
-        roleSuffix: "prod-deploy",
-        subjectType: "repository",
-        subject: "repo:org-b@222/new-repo@12345:*",
-        iamRoleName: "r",
-        iamRoleArn: "arn",
-        createdAt: "2024-01-01",
-      },
-      cfg
-    );
+    const output = buildResourceOutput({
+      repositoryName: "org-b/new-repo/prod-deploy",
+      gitHubRepositoryName: "new-repo",
+      gitHubOrgName: "org-b",
+      gitHubRepositoryId: "12345",
+      gitHubOrgId: "222",
+      roleSuffix: "prod-deploy",
+      subjectType: "repository",
+      subject: "repo:org-b@222/new-repo@12345:*",
+      iamRoleName: "r",
+      iamRoleArn: "arn",
+      createdAt: "2024-01-01",
+    });
     expect(output.resourceId).toBe("org-b/new-repo/prod-deploy");
     expect(output.name).toBe("org-b/new-repo/prod-deploy");
     expect(output.params.roleSuffix).toBe("prod-deploy");


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### 🎉 Reason for this change

`npm run lint` fails on `main`:

```
catalogs/iam-role/src/handlers/gitHubIamRoleResource.ts
  41:3  error  '_config' is defined but never used  @typescript-eslint/no-unused-vars
```

### 🔀 Description of changes

Remove the unused `_config` parameter from `resolveDisplayFields`. Since `buildResourceOutput` only received `config` to forward it there, its parameter became unused too, so both are dropped along with their call sites.

No behavior change.

### 🖨️ Description of how you validated changes

- `npm run lint` passes (previously failed)
- `tsc --noEmit` / `npm run build` pass
- 63 unit tests pass

### 👀 Points to be checked especially by reviewers (if any)

None — mechanical removal.

### 🔗 Related links

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)