### PR TITLE
feat(iam-role): support branch/environment/tag/pull_request OIDC subject scoping

### DIFF
--- a/catalogs/iam-role/README.md
+++ b/catalogs/iam-role/README.md
@@ -123,7 +123,22 @@ When a user creates a `github-iam-role` resource they provide:
 | `repositoryName` | ✓ | Bare repository name (without org prefix). |
 | `repositoryId` | ✓ | Immutable numeric repository ID: `curl -s https://api.github.com/repos/{owner}/{repo} \| jq .id` |
 | `roleSuffix` | – | 1-32 chars (`[a-zA-Z0-9-]`, must start/end alphanumeric). Distinguishes multiple IAM roles for the same repository. |
-| `subjectType` | – | Defaults to `repository` (whole-repo scope). Other scopes (branch / environment / tag / pull_request) are planned but not yet supported. |
+| `subjectType` | – | Scope of the OIDC sub condition: `repository` (default), `branch`, `environment`, `tag`, or `pull_request`. |
+| `subjectValue` | – | Branch / environment / tag name. Required for `branch` / `environment` / `tag`, must be empty otherwise. Max 256 chars; wildcard characters (`*`, `?`) are rejected because the condition uses `StringLike`. |
+
+#### Subject scoping rules
+
+| `subjectType` | trust policy sub condition | typical use |
+| --- | --- | --- |
+| `repository` (default) | `repo:ORG@ORG_ID/REPO@REPO_ID:*` | any workflow in the repository |
+| `branch` | `repo:ORG@ORG_ID/REPO@REPO_ID:ref:refs/heads/<subjectValue>` | push/deploy from a specific branch |
+| `tag` | `repo:ORG@ORG_ID/REPO@REPO_ID:ref:refs/tags/<subjectValue>` | release workflows triggered by a tag |
+| `environment` | `repo:ORG@ORG_ID/REPO@REPO_ID:environment:<subjectValue>` | jobs bound to a GitHub environment (recommended for production deploys) |
+| `pull_request` | `repo:ORG@ORG_ID/REPO@REPO_ID:pull_request` | pull-request-triggered workflows |
+
+Combine `subjectType` with `roleSuffix` to give one repository multiple roles
+with different scopes (e.g. a repo-wide read role and an
+environment-restricted deploy role).
 
 #### Immutable OIDC subject claims
 
@@ -184,7 +199,7 @@ role names/ARNs across delete-and-recreate migrations.
   resolved correctly by `getResource` / `deleteResource` / promote requests.
 - DynamoDB schema (`cf-db-template.yaml`) is unchanged. New attributes
   (`gitHubRepositoryName`, `gitHubOrgName`, `gitHubRepositoryId`, `gitHubOrgId`,
-  `roleSuffix`, `subjectType`, `subject`) are written to newly created records;
+  `roleSuffix`, `subjectType`, `subjectValue`, `subject`) are written to newly created records;
   legacy records without those attributes are still readable. The persisted
   `subject` records the exact sub condition written to the trust policy for
   auditability. Record creation now uses a conditional put

--- a/catalogs/iam-role/src/events/database/gitHubIamRoleDB.ts
+++ b/catalogs/iam-role/src/events/database/gitHubIamRoleDB.ts
@@ -148,6 +148,7 @@ export const createGitHubIamRoleDBItem =
       gitHubOrgId: input.gitHubOrgId,
       roleSuffix: input.roleSuffix,
       subjectType: input.subjectType,
+      subjectValue: input.subjectValue,
       subject: input.subject,
       iamRoleName: input.iamRoleName,
       iamRoleArn: input.iamRoleArn,

--- a/catalogs/iam-role/src/events/resource/gitHubIamRole.ts
+++ b/catalogs/iam-role/src/events/resource/gitHubIamRole.ts
@@ -22,9 +22,9 @@ import {
  * name-only format will NOT match roles created with this condition — such
  * repositories must opt in to the immutable format first.
  *
- * Only the whole-repository scope is supported today; the signature accepts
- * `subjectType` so branch / environment / tag / pull_request scoping can be
- * added without changing call sites.
+ * `subjectValue` is required for branch / environment / tag and must be absent
+ * otherwise — enforced by the CreateGitHubIamRoleNameCommand schema; this
+ * function throws if called with an invalid pairing (programming error).
  */
 export const buildGitHubSubjectClaim = (input: {
   gitHubOrgName: string;
@@ -32,11 +32,26 @@ export const buildGitHubSubjectClaim = (input: {
   repositoryName: string;
   repositoryId: string;
   subjectType: SubjectType;
+  subjectValue?: string;
 }): string => {
   const base = `repo:${input.gitHubOrgName}@${input.gitHubOrgId}/${input.repositoryName}@${input.repositoryId}`;
+  const requireValue = (): string => {
+    if (!input.subjectValue) {
+      throw new Error(`subjectValue is required for subjectType "${input.subjectType}"`);
+    }
+    return input.subjectValue;
+  };
   switch (input.subjectType) {
     case "repository":
       return `${base}:*`;
+    case "branch":
+      return `${base}:ref:refs/heads/${requireValue()}`;
+    case "tag":
+      return `${base}:ref:refs/tags/${requireValue()}`;
+    case "environment":
+      return `${base}:environment:${requireValue()}`;
+    case "pull_request":
+      return `${base}:pull_request`;
   }
 };
 
@@ -79,14 +94,11 @@ export const createGitHubIamRoleName =
       repositoryName: parsedInput.repositoryName,
       repositoryId: parsedInput.repositoryId,
       subjectType: parsedInput.subjectType,
+      subjectValue: parsedInput.subjectValue,
     });
     return ok({
-      repositoryName: parsedInput.repositoryName,
-      gitHubOrgName: parsedInput.gitHubOrgName,
-      repositoryId: parsedInput.repositoryId,
+      ...parsedInput,
       gitHubOrgId: allowedOrg.id,
-      roleSuffix: parsedInput.roleSuffix,
-      subjectType: parsedInput.subjectType,
       subject,
       iamRoleName,
     });

--- a/catalogs/iam-role/src/events/resource/gitHubIamRole.unit.test.ts
+++ b/catalogs/iam-role/src/events/resource/gitHubIamRole.unit.test.ts
@@ -21,15 +21,41 @@ const baseConfig: IamRoleCatalogConfig = IamRoleCatalogConfig.parse({
 });
 
 describe("buildGitHubSubjectClaim", () => {
+  const base = {
+    gitHubOrgName: "org-a",
+    gitHubOrgId: "111",
+    repositoryName: "my-repo",
+    repositoryId: "12345",
+  } as const;
+
   it("builds the immutable whole-repository subject", () => {
-    const subject = buildGitHubSubjectClaim({
-      gitHubOrgName: "org-a",
-      gitHubOrgId: "111",
-      repositoryName: "my-repo",
-      repositoryId: "12345",
-      subjectType: "repository",
-    });
-    expect(subject).toBe("repo:org-a@111/my-repo@12345:*");
+    expect(buildGitHubSubjectClaim({ ...base, subjectType: "repository" })).toBe("repo:org-a@111/my-repo@12345:*");
+  });
+
+  it("builds the branch-scoped subject (branch names may contain slashes)", () => {
+    expect(buildGitHubSubjectClaim({ ...base, subjectType: "branch", subjectValue: "release/v1" })).toBe(
+      "repo:org-a@111/my-repo@12345:ref:refs/heads/release/v1"
+    );
+  });
+
+  it("builds the tag-scoped subject", () => {
+    expect(buildGitHubSubjectClaim({ ...base, subjectType: "tag", subjectValue: "v1.0.0" })).toBe(
+      "repo:org-a@111/my-repo@12345:ref:refs/tags/v1.0.0"
+    );
+  });
+
+  it("builds the environment-scoped subject", () => {
+    expect(buildGitHubSubjectClaim({ ...base, subjectType: "environment", subjectValue: "production" })).toBe(
+      "repo:org-a@111/my-repo@12345:environment:production"
+    );
+  });
+
+  it("builds the pull_request subject", () => {
+    expect(buildGitHubSubjectClaim({ ...base, subjectType: "pull_request" })).toBe("repo:org-a@111/my-repo@12345:pull_request");
+  });
+
+  it.each(["branch", "tag", "environment"] as const)("throws when subjectValue is missing for %s (guarded by schema upstream)", (subjectType) => {
+    expect(() => buildGitHubSubjectClaim({ ...base, subjectType })).toThrow("subjectValue is required");
   });
 });
 
@@ -173,6 +199,74 @@ describe("createGitHubIamRoleName (multi-org)", () => {
     });
     expect(result.isErr()).toBe(true);
   });
+
+  it.each([
+    ["branch", "main", "repo:org-a@111/my-repo@12345:ref:refs/heads/main"],
+    ["tag", "v1.0.0", "repo:org-a@111/my-repo@12345:ref:refs/tags/v1.0.0"],
+    ["environment", "production", "repo:org-a@111/my-repo@12345:environment:production"],
+  ] as const)("builds a %s-scoped subject when subjectValue is given", (subjectType, subjectValue, expectedSubject) => {
+    const result = createGitHubIamRoleName(baseConfig)({
+      repositoryName: "my-repo",
+      gitHubOrgName: "org-a",
+      repositoryId: "12345",
+      subjectType,
+      subjectValue,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.subject).toBe(expectedSubject);
+      expect(result.value.subjectType).toBe(subjectType);
+      expect(result.value.subjectValue).toBe(subjectValue);
+      // The scope does not change the role name — multiple scopes for one
+      // repo are distinguished by roleSuffix.
+      expect(result.value.iamRoleName).toBe("stamp-github-org-a-my-repo");
+    }
+  });
+
+  it("builds the pull_request subject without a value", () => {
+    const result = createGitHubIamRoleName(baseConfig)({
+      repositoryName: "my-repo",
+      gitHubOrgName: "org-a",
+      repositoryId: "12345",
+      subjectType: "pull_request",
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.subject).toBe("repo:org-a@111/my-repo@12345:pull_request");
+    }
+  });
+
+  it.each(["branch", "environment", "tag"] as const)("rejects %s without subjectValue via runtime schema validation", (subjectType) => {
+    const result = createGitHubIamRoleName(baseConfig)({
+      repositoryName: "my-repo",
+      gitHubOrgName: "org-a",
+      repositoryId: "12345",
+      subjectType,
+    } as Parameters<ReturnType<typeof createGitHubIamRoleName>>[0]);
+    expect(result.isErr()).toBe(true);
+  });
+
+  it.each(["repository", "pull_request"] as const)("rejects %s with a subjectValue via runtime schema validation", (subjectType) => {
+    const result = createGitHubIamRoleName(baseConfig)({
+      repositoryName: "my-repo",
+      gitHubOrgName: "org-a",
+      repositoryId: "12345",
+      subjectType,
+      subjectValue: "main",
+    } as unknown as Parameters<ReturnType<typeof createGitHubIamRoleName>>[0]);
+    expect(result.isErr()).toBe(true);
+  });
+
+  it.each(["main*", "ma?in", "", "a".repeat(257)])("rejects an invalid subjectValue (%j)", (subjectValue) => {
+    const result = createGitHubIamRoleName(baseConfig)({
+      repositoryName: "my-repo",
+      gitHubOrgName: "org-a",
+      repositoryId: "12345",
+      subjectType: "branch",
+      subjectValue,
+    });
+    expect(result.isErr()).toBe(true);
+  });
 });
 
 describe("createGitHubIamRoleInAws (trust policy shape)", () => {
@@ -230,5 +324,33 @@ describe("createGitHubIamRoleInAws (trust policy shape)", () => {
       expect(result.value.iamRoleArn).toBe("arn:aws:iam::123456789012:role/stamp-github-org-a-my-repo");
       expect(result.value.subject).toBe("repo:org-a@111/my-repo@12345:*");
     }
+  });
+
+  it("writes a branch-scoped sub condition to the assume-role policy", async () => {
+    const send = vi.fn().mockResolvedValue({ Role: { Arn: "arn:aws:iam::123456789012:role/stamp-github-org-a-my-repo-deploy" } });
+    const iamClient = { send } as unknown as IAMClient;
+
+    const result = await createGitHubIamRoleInAws(
+      logger,
+      baseConfig,
+      iamClient
+    )({
+      repositoryName: "my-repo",
+      gitHubOrgName: "org-a",
+      repositoryId: "12345",
+      gitHubOrgId: "111",
+      roleSuffix: "deploy",
+      subjectType: "branch",
+      subjectValue: "main",
+      subject: "repo:org-a@111/my-repo@12345:ref:refs/heads/main",
+      iamRoleName: "stamp-github-org-a-my-repo-deploy",
+    });
+
+    expect(result.isOk()).toBe(true);
+    const command = send.mock.calls[0][0] as CreateRoleCommand;
+    const policy = JSON.parse(command.input.AssumeRolePolicyDocument as string);
+    expect(policy.Statement[0].Condition.StringLike["token.actions.githubusercontent.com:sub"]).toBe(
+      "repo:org-a@111/my-repo@12345:ref:refs/heads/main"
+    );
   });
 });

--- a/catalogs/iam-role/src/handlers/gitHubIamRoleResource.test.ts
+++ b/catalogs/iam-role/src/handlers/gitHubIamRoleResource.test.ts
@@ -23,6 +23,8 @@ const repositoryId = "9876543";
 const expectedSubject = `repo:${githubOrgName}@${gitHubOrgId}/${repositoryName}@${repositoryId}:*`;
 const roleSuffix = "it-suffix";
 const suffixedResourceId = `${githubOrgName}/${repositoryName}/${roleSuffix}`;
+const envRoleSuffix = "it-env";
+const envScopedResourceId = `${githubOrgName}/${repositoryName}/${envRoleSuffix}`;
 
 const config: IamRoleCatalogConfig = {
   region: "us-west-2",
@@ -41,13 +43,13 @@ const gitHubIamRoleResource = createGitHubIamRoleResourceHandler(config);
 
 describe("Testing gitHubIamRoleResource", () => {
   beforeAll(async () => {
-    for (const resourceId of [repositoryResourceId, suffixedResourceId]) {
+    for (const resourceId of [repositoryResourceId, suffixedResourceId, envScopedResourceId]) {
       await gitHubIamRoleResource.deleteResource({ resourceTypeId, resourceId });
     }
   });
 
   afterAll(async () => {
-    for (const resourceId of [repositoryResourceId, suffixedResourceId]) {
+    for (const resourceId of [repositoryResourceId, suffixedResourceId, envScopedResourceId]) {
       await gitHubIamRoleResource.deleteResource({ resourceTypeId, resourceId });
     }
   });
@@ -137,6 +139,42 @@ describe("Testing gitHubIamRoleResource", () => {
         throw stillThere.error;
       }
       expect(stillThere.value.isSome()).toBe(true);
+    });
+
+    it("creates an environment-scoped role", async () => {
+      const input: CreateResourceInput = {
+        resourceTypeId: resourceTypeId,
+        inputParams: {
+          repositoryName: repositoryName,
+          gitHubOrgName: githubOrgName,
+          repositoryId: repositoryId,
+          roleSuffix: envRoleSuffix,
+          subjectType: "environment",
+          subjectValue: "production",
+        },
+      };
+      const expected: ResourceOutput = {
+        params: {
+          repositoryName: repositoryName,
+          gitHubOrgName: githubOrgName,
+          repositoryId: repositoryId,
+          roleSuffix: envRoleSuffix,
+          subjectType: "environment",
+          subjectValue: "production",
+          subject: `repo:${githubOrgName}@${gitHubOrgId}/${repositoryName}@${repositoryId}:environment:production`,
+          iamRoleArn: expect.any(String),
+        },
+        name: envScopedResourceId,
+        resourceId: envScopedResourceId,
+      };
+      const result = await gitHubIamRoleResource.createResource(input);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value).toEqual(expected);
+
+      const deleted = await gitHubIamRoleResource.deleteResource({ resourceTypeId, resourceId: envScopedResourceId });
+      expect(deleted.isOk()).toBe(true);
     });
 
     it("returns failed result if repository name is empty", async () => {

--- a/catalogs/iam-role/src/handlers/gitHubIamRoleResource.ts
+++ b/catalogs/iam-role/src/handlers/gitHubIamRoleResource.ts
@@ -25,7 +25,15 @@ import {
 import { createGitHubIamRoleInAws, createGitHubIamRoleName, deleteGitHubIamRoleInAws, listGitHubIamRoleAuditItemInAws } from "../events/resource/gitHubIamRole";
 import { listIamRoleAttachedPolicyArns, fetchAllAttachedRolePolicyArns } from "../events/iam-ops/iamRoleManagement";
 import { assumeRoleCredentialProvider } from "../utils/assumeRoleCredentialProvider";
-import { GitHubIamRole, GitHubOrgNameField, GitHubRepositoryIdField, GitHubRepositoryNameField, RoleSuffixField, SubjectTypeField } from "../types/gitHubIamRole";
+import {
+  GitHubIamRole,
+  GitHubOrgNameField,
+  GitHubRepositoryIdField,
+  GitHubRepositoryNameField,
+  RoleSuffixField,
+  SubjectTypeField,
+  SubjectValueField,
+} from "../types/gitHubIamRole";
 
 /**
  * Resolves the user-facing repository name and GitHub organization for a
@@ -74,6 +82,9 @@ export const buildResourceOutput = (item: GitHubIamRole): ResourceOutput => {
   }
   if (item.subjectType) {
     params.subjectType = item.subjectType;
+  }
+  if (item.subjectValue) {
+    params.subjectValue = item.subjectValue;
   }
   if (item.subject) {
     params.subject = item.subject;
@@ -152,9 +163,9 @@ const createResourceHandler =
         "Invalid input parameters(roleSuffix): must be 1-32 alphanumeric/hyphen characters, starting and ending with an alphanumeric character";
       return err(new HandlerError(message, "BAD_REQUEST", message));
     }
-    // Optional: defaults to "repository" (whole-repo scope). Other subject
-    // types (branch / environment / tag / pull_request) are planned but not
-    // yet supported.
+    // Optional: defaults to "repository" (whole-repo scope). branch /
+    // environment / tag scope the sub condition to a single ref or
+    // environment and require subjectValue; repository / pull_request forbid it.
     const rawSubjectType = input.inputParams.subjectType;
     if (rawSubjectType !== undefined && typeof rawSubjectType !== "string") {
       return err(new HandlerError("Invalid input parameters(subjectType)", "BAD_REQUEST", "Invalid input parameters(subjectType)"));
@@ -163,10 +174,39 @@ const createResourceHandler =
       typeof rawSubjectType === "string" && rawSubjectType.trim() !== "" ? rawSubjectType.trim() : undefined
     );
     if (!subjectTypeParseResult.success) {
-      const message = `Invalid input parameters(subjectType): "${rawSubjectType}" is not yet supported. Supported values: repository (default).`;
+      const message = `Invalid input parameters(subjectType): "${rawSubjectType}" is not supported. Supported values: repository (default), branch, environment, tag, pull_request.`;
       return err(new HandlerError(message, "BAD_REQUEST", message));
     }
     const subjectType = subjectTypeParseResult.data;
+
+    const rawSubjectValue = input.inputParams.subjectValue;
+    if (rawSubjectValue !== undefined && typeof rawSubjectValue !== "string") {
+      return err(new HandlerError("Invalid input parameters(subjectValue)", "BAD_REQUEST", "Invalid input parameters(subjectValue)"));
+    }
+    const subjectValue = typeof rawSubjectValue === "string" && rawSubjectValue.trim() !== "" ? rawSubjectValue.trim() : undefined;
+    // Literal comparisons (not a helper) so TypeScript narrows subjectType and
+    // the resulting pair satisfies the CreateGitHubIamRoleNameCommand union.
+    let subjectSpec:
+      | { subjectType: "branch" | "environment" | "tag"; subjectValue: string }
+      | { subjectType: "repository" | "pull_request"; subjectValue?: undefined };
+    if (subjectType === "branch" || subjectType === "environment" || subjectType === "tag") {
+      if (subjectValue === undefined) {
+        const message = `Invalid input parameters(subjectValue): required when subjectType is "${subjectType}"`;
+        return err(new HandlerError(message, "BAD_REQUEST", message));
+      }
+      if (!SubjectValueField.safeParse(subjectValue).success) {
+        const message =
+          "Invalid input parameters(subjectValue): must be 1-256 characters and must not contain wildcard characters (* or ?)";
+        return err(new HandlerError(message, "BAD_REQUEST", message));
+      }
+      subjectSpec = { subjectType, subjectValue };
+    } else {
+      if (subjectValue !== undefined) {
+        const message = `Invalid input parameters(subjectValue): must be empty when subjectType is "${subjectType}"`;
+        return err(new HandlerError(message, "BAD_REQUEST", message));
+      }
+      subjectSpec = { subjectType };
+    }
 
     const repositoryId = input.inputParams.repositoryId.trim();
     const pkValue = buildGitHubIamRolePkValue(gitHubOrgName, repositoryName, roleSuffix);
@@ -214,7 +254,7 @@ const createResourceHandler =
       gitHubOrgName,
       repositoryId,
       roleSuffix,
-      subjectType,
+      ...subjectSpec,
     };
 
     const iamClient = new IAMClient({

--- a/catalogs/iam-role/src/handlers/gitHubIamRoleResource.unit.test.ts
+++ b/catalogs/iam-role/src/handlers/gitHubIamRoleResource.unit.test.ts
@@ -219,18 +219,85 @@ describe("createResource input validation (short-circuits before any AWS call)",
     }
   });
 
-  it.each(["branch", "environment", "tag", "pull_request", "bogus"])(
-    "rejects the not-yet-supported subjectType %j",
-    async (subjectType) => {
-      const result = await createResource({
-        ...baseInput,
-        inputParams: { ...baseInput.inputParams, subjectType },
-      });
-      expect(result.isErr()).toBe(true);
-      if (result.isErr()) {
-        expect(result.error.code).toBe("BAD_REQUEST");
-        expect(result.error.userMessage).toContain("subjectType");
-      }
+  it.each(["bogus", "Branch", "repo"])("rejects an unknown subjectType (%j)", async (subjectType) => {
+    const result = await createResource({
+      ...baseInput,
+      inputParams: { ...baseInput.inputParams, subjectType },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("BAD_REQUEST");
+      expect(result.error.userMessage).toContain("subjectType");
     }
-  );
+  });
+
+  it.each(["branch", "environment", "tag"])("rejects subjectType %j without a subjectValue", async (subjectType) => {
+    const result = await createResource({
+      ...baseInput,
+      inputParams: { ...baseInput.inputParams, subjectType },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("BAD_REQUEST");
+      expect(result.error.userMessage).toContain("subjectValue");
+      expect(result.error.userMessage).toContain("required");
+    }
+  });
+
+  it.each([
+    ["repository", "main"],
+    ["pull_request", "main"],
+  ])("rejects subjectType %j with a subjectValue (%j)", async (subjectType, subjectValue) => {
+    const result = await createResource({
+      ...baseInput,
+      inputParams: { ...baseInput.inputParams, subjectType, subjectValue },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("BAD_REQUEST");
+      expect(result.error.userMessage).toContain("must be empty");
+    }
+  });
+
+  it("rejects a subjectValue omitted-with-value pairing even when subjectType is omitted (defaults to repository)", async () => {
+    const result = await createResource({
+      ...baseInput,
+      inputParams: { ...baseInput.inputParams, subjectValue: "main" },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.userMessage).toContain("must be empty");
+    }
+  });
+
+  it.each(["release*", "ma?in", "a".repeat(257)])("rejects a subjectValue with wildcard or over-length content (%j)", async (subjectValue) => {
+    const result = await createResource({
+      ...baseInput,
+      inputParams: { ...baseInput.inputParams, subjectType: "branch", subjectValue },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("BAD_REQUEST");
+      expect(result.error.userMessage).toContain("subjectValue");
+    }
+  });
+
+  it("buildResourceOutput exposes subjectValue when present", () => {
+    const output = buildResourceOutput({
+      repositoryName: "org-a/my-repo/deploy",
+      gitHubRepositoryName: "my-repo",
+      gitHubOrgName: "org-a",
+      gitHubRepositoryId: "12345",
+      gitHubOrgId: "111",
+      roleSuffix: "deploy",
+      subjectType: "branch",
+      subjectValue: "main",
+      subject: "repo:org-a@111/my-repo@12345:ref:refs/heads/main",
+      iamRoleName: "r",
+      iamRoleArn: "arn",
+      createdAt: "2024-01-01",
+    });
+    expect(output.params.subjectValue).toBe("main");
+    expect(output.params.subjectType).toBe("branch");
+  });
 });

--- a/catalogs/iam-role/src/index.ts
+++ b/catalogs/iam-role/src/index.ts
@@ -50,7 +50,8 @@ export function createIamRoleCatalog(iamRoleCatalogConfigInput: IamRoleCatalogCo
       { type: "string", id: "repositoryName", name: "Repository Name", required: true },
       { type: "string", id: "repositoryId", name: "Repository ID (numeric)", required: true },
       { type: "string", id: "roleSuffix", name: "Role Suffix (optional, for multiple roles per repository)", required: false },
-      { type: "string", id: "subjectType", name: "Subject Type (optional, default: repository)", required: false },
+      { type: "string", id: "subjectType", name: "Subject Type (optional, default: repository; one of repository, branch, environment, tag, pull_request)", required: false },
+      { type: "string", id: "subjectValue", name: "Subject Value (required for branch/environment/tag)", required: false },
     ],
     infoParams: [
       { type: "string", id: "gitHubOrgName", name: "GitHub Organization", edit: false },
@@ -58,6 +59,7 @@ export function createIamRoleCatalog(iamRoleCatalogConfigInput: IamRoleCatalogCo
       { type: "string", id: "repositoryId", name: "Repository ID", edit: false },
       { type: "string", id: "roleSuffix", name: "Role Suffix", edit: false },
       { type: "string", id: "subjectType", name: "Subject Type", edit: false },
+      { type: "string", id: "subjectValue", name: "Subject Value", edit: false },
       { type: "string", id: "subject", name: "OIDC Subject Claim", edit: false },
       { type: "string", id: "iamRoleArn", name: "IAM Role Arn", edit: false },
     ],

--- a/catalogs/iam-role/src/types/gitHubIamRole.ts
+++ b/catalogs/iam-role/src/types/gitHubIamRole.ts
@@ -44,36 +44,81 @@ export const RoleSuffixField = z
   .regex(/^[a-zA-Z0-9]([a-zA-Z0-9-]{0,30}[a-zA-Z0-9])?$/, "roleSuffix must be 1-32 alphanumeric/hyphen characters, starting and ending alphanumeric");
 
 /**
- * Scope of the OIDC subject claim condition. Only `repository` (whole-repo,
- * `repo:ORG@ID/REPO@ID:*`) is supported today; branch / environment / tag /
- * pull_request scoping is planned as a follow-up.
+ * Scope of the OIDC subject claim condition:
+ * - `repository` (default): whole repository, `repo:ORG@ID/REPO@ID:*`
+ * - `branch` / `tag` / `environment`: a single ref or environment (requires `subjectValue`)
+ * - `pull_request`: pull-request-triggered workflows only
  */
-export const SubjectTypeField = z.enum(["repository"]).default("repository");
+export const SubjectTypeField = z.enum(["repository", "branch", "environment", "tag", "pull_request"]).default("repository");
 export type SubjectType = z.infer<typeof SubjectTypeField>;
 
-export const CreateGitHubIamRoleNameCommand = z.object({
+/** Subject types whose sub condition embeds a user-supplied value. */
+export const SubjectTypeWithValue = z.enum(["branch", "environment", "tag"]);
+/** Subject types that take no value. Defaults to `repository` when omitted. */
+export const SubjectTypeWithoutValue = z.enum(["repository", "pull_request"]).default("repository");
+
+/**
+ * Branch / tag / environment name embedded verbatim in the sub condition.
+ * Wildcard characters are rejected: the condition uses StringLike, and a `*`
+ * or `?` inside the value would silently widen the trust policy scope.
+ */
+export const SubjectValueField = z
+  .string()
+  .min(1)
+  .max(256)
+  .refine((value) => !/[*?]/.test(value), "subjectValue must not contain wildcard characters (* or ?)");
+
+const CreateGitHubIamRoleNameCommandCommonFields = {
   repositoryName: GitHubRepositoryNameField,
   gitHubOrgName: GitHubOrgNameField,
   repositoryId: GitHubRepositoryIdField,
   roleSuffix: RoleSuffixField.optional(),
-  subjectType: SubjectTypeField,
+};
+
+// Union couples subjectType to subjectValue cardinality: branch/environment/tag
+// require a value, repository/pull_request forbid one. Modeling this in the
+// schema (instead of an after-the-fact refine) keeps every downstream consumer
+// of the parsed command working with a valid pairing.
+const ValueScopedCommandOption = z.object({
+  ...CreateGitHubIamRoleNameCommandCommonFields,
+  subjectType: SubjectTypeWithValue,
+  subjectValue: SubjectValueField,
 });
+const RepoScopedCommandOption = z.object({
+  ...CreateGitHubIamRoleNameCommandCommonFields,
+  subjectType: SubjectTypeWithoutValue,
+  subjectValue: z.undefined().optional(),
+});
+
+export const CreateGitHubIamRoleNameCommand = z.union([ValueScopedCommandOption, RepoScopedCommandOption]);
 export type CreateGitHubIamRoleNameCommand = z.infer<typeof CreateGitHubIamRoleNameCommand>;
 
-export const CreatedGitHubIamRoleName = CreateGitHubIamRoleNameCommand.merge(
-  z.object({
-    iamRoleName: z.string(),
-    gitHubOrgId: GitHubOrgIdField,
-    /** Fully assembled OIDC subject claim condition written to the trust policy. */
-    subject: z.string().min(1),
-  })
-);
+const CreatedGitHubIamRoleNameFields = {
+  iamRoleName: z.string(),
+  gitHubOrgId: GitHubOrgIdField,
+  /** Fully assembled OIDC subject claim condition written to the trust policy. */
+  subject: z.string().min(1),
+};
+
+export const CreatedGitHubIamRoleName = z.union([
+  ValueScopedCommandOption.extend(CreatedGitHubIamRoleNameFields),
+  RepoScopedCommandOption.extend(CreatedGitHubIamRoleNameFields),
+]);
 export type CreatedGitHubIamRoleName = z.infer<typeof CreatedGitHubIamRoleName>;
 
 export const CreateGitHubIamRoleCommand = CreatedGitHubIamRoleName;
 export type CreateGitHubIamRoleCommand = z.infer<typeof CreateGitHubIamRoleCommand>;
 
-export const CreatedGitHubIamRole = CreatedGitHubIamRoleName.merge(z.object({ iamRoleArn: z.string(), createdAt: z.string().datetime() }));
+const CreatedGitHubIamRoleFields = {
+  ...CreatedGitHubIamRoleNameFields,
+  iamRoleArn: z.string(),
+  createdAt: z.string().datetime(),
+};
+
+export const CreatedGitHubIamRole = z.union([
+  ValueScopedCommandOption.extend(CreatedGitHubIamRoleFields),
+  RepoScopedCommandOption.extend(CreatedGitHubIamRoleFields),
+]);
 export type CreatedGitHubIamRole = z.infer<typeof CreatedGitHubIamRole>;
 
 /**
@@ -120,6 +165,10 @@ export const GitHubIamRole = z.object({
     .optional()
     .transform((v) => (v ? v : undefined)),
   subjectType: z
+    .string()
+    .optional()
+    .transform((v) => (v ? v : undefined)),
+  subjectValue: z
     .string()
     .optional()
     .transform((v) => (v ? v : undefined)),


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### 🎉 Reason for this change

Follow-up to #95. The github-iam-role trust policy currently always grants the whole repository (`repo:ORG@ID/REPO@ID:*`). This adds stricter OIDC subject scoping so a role can be limited to a specific branch, tag, environment, or to pull-request-triggered workflows.

### 🔀 Description of changes

**New createParams**

| param | required | description |
| --- | --- | --- |
| `subjectType` | – | `repository` (default), `branch`, `environment`, `tag`, `pull_request` |
| `subjectValue` | – | Required for `branch` / `environment` / `tag`, must be empty otherwise. Max 256 chars; `*` and `?` rejected (condition uses `StringLike`, a wildcard would silently widen the scope) |

**Sub condition per scope** (immutable format base `repo:ORG@ORG_ID/REPO@REPO_ID`)

| subjectType | sub |
| --- | --- |
| repository | `…:*` |
| branch | `…:ref:refs/heads/<value>` |
| tag | `…:ref:refs/tags/<value>` |
| environment | `…:environment:<value>` |
| pull_request | `…:pull_request` |

**Design decisions**

- The `subjectType`↔`subjectValue` pairing is modeled as a zod union (`CreateGitHubIamRoleNameCommand` and derived schemas), so every parsed command is a valid combination — no after-the-fact checks downstream.
- The scope does not change the IAM role name or resourceId; multiple scopes for one repository are distinguished by `roleSuffix` (from #95).
- `subjectValue` is persisted to DynamoDB (lenient/optional on read, same as the other immutable-claims attributes) and exposed via infoParams.

### 🖨️ Description of how you validated changes

- `tsc --noEmit` / `npm run build` / `npm run lint` pass.
- 92 unit tests pass, including: `buildGitHubSubjectClaim` for all five scopes, schema rejection of invalid pairings (branch without value, pull_request with value), wildcard/over-length `subjectValue` rejection, and a branch-scoped trust-policy JSON assertion via a stubbed IAM client.
- Integration tests updated (environment-scoped create scenario added) but **not yet run** — requires AWS credentials; will run before marking ready for review.

### 👀 Points to be checked especially by reviewers (if any)

- The zod union restructuring of `CreateGitHubIamRoleNameCommand` / `CreatedGitHubIamRoleName` / `CreatedGitHubIamRole` (previously flat objects with `.merge`).
- Whether `subjectValue` validation should be stricter (e.g. git ref charset). Currently only length + wildcard rejection.

### 🔗 Related links

- #95 (immutable OIDC subject claims; this builds on it)
- https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/

🤖 Generated with [Claude Code](https://claude.com/claude-code)