### PR TITLE
feat(resource): add requesterGroupIds / visibility settings and listByResourceType (stack 1/4)

### DIFF
--- a/packages/hub/src/inputAuthzModel.ts
+++ b/packages/hub/src/inputAuthzModel.ts
@@ -18,6 +18,8 @@ import {
   DeleteAuditNotificationInput,
   UpdateResourceParamsInput,
   CancelUpdateResourceParamsWithApprovalInput,
+  UpdateResourceRequesterGroupsInput as WorkflowUpdateResourceRequesterGroupsInput,
+  UpdateResourceVisibilityInput as WorkflowUpdateResourceVisibilityInput,
 } from "./workflows/resource/input";
 import { UserId } from "@stamp-lib/stamp-types/pluginInterface/identity";
 import { ApprovalFlowInfo } from "@stamp-lib/stamp-types/models";
@@ -42,8 +44,9 @@ export const EditResourceInput = z.union([
   CreateAuditNotificationInput,
   DeleteAuditNotificationInput,
   UpdateResourceParamsInput,
-  UpdateResourceParamsInput,
   CancelUpdateResourceParamsWithApprovalInput,
+  WorkflowUpdateResourceRequesterGroupsInput,
+  WorkflowUpdateResourceVisibilityInput,
 ]);
 export type EditResourceInput = z.infer<typeof EditResourceInput>;
 
@@ -52,6 +55,12 @@ export type UpdateResourceApproverInput = z.infer<typeof UpdateResourceApproverI
 
 export const UpdateResourceOwnerInput = WorkflowUpdateResourceOwnerInput;
 export type UpdateResourceOwnerInput = z.infer<typeof UpdateResourceOwnerInput>;
+
+export const UpdateResourceRequesterGroupsInput = WorkflowUpdateResourceRequesterGroupsInput;
+export type UpdateResourceRequesterGroupsInput = z.infer<typeof UpdateResourceRequesterGroupsInput>;
+
+export const UpdateResourceVisibilityInput = WorkflowUpdateResourceVisibilityInput;
+export type UpdateResourceVisibilityInput = z.infer<typeof UpdateResourceVisibilityInput>;
 
 export const EditApprovalFlowInput = z.object({ catalogId: z.string(), approvalFlowId: z.string(), requestUserId: UserId });
 export type EditApprovalFlowInput = z.infer<typeof EditApprovalFlowInput>;

--- a/packages/hub/src/route/userRequest/resource.ts
+++ b/packages/hub/src/route/userRequest/resource.ts
@@ -23,12 +23,16 @@ import {
   UpdateResourceOwnerInput,
   UpdateResourceParamsWithApprovalInput,
   UpdateResourceParamsInput,
+  UpdateResourceRequesterGroupsInput,
+  UpdateResourceVisibilityInput,
 } from "../../workflows/resource/input";
 import { listResourceAuditItem } from "../../workflows/resource/listResourceAuditItem";
 import { listResourceOutlines } from "../../workflows/resource/listResourceOutlines";
 import { updateAuditNotification } from "../../workflows/resource/updateAuditNotification";
 import { updateResourceApprover } from "../../workflows/resource/updateResourceApprover";
 import { updateResourceOwner } from "../../workflows/resource/updateResourceOwner";
+import { updateResourceRequesterGroups } from "../../workflows/resource/updateResourceRequesterGroups";
+import { updateResourceVisibility } from "../../workflows/resource/updateResourceVisibility";
 import { updateResourceParamsWithApproval, createWorkflowDependencies } from "../../workflows/resource/updateResourceParamsWithApproval/index";
 import { cancelUpdateResourceParamsWithApproval } from "../../workflows/resource/cancelUpdateResourceParamsWithApproval";
 import { updateResourceParams } from "../../workflows/resource/updateResourceParams";
@@ -154,6 +158,27 @@ export const resourceRouter = router({
       getGroupMemberShip: ctx.identity.groupMemberShip.get,
     })(input).mapErr(convertTRPCError(logger));
     return unwrapOrthrowTRPCError(updateResourceOwnerResult);
+  }),
+  updateRequesterGroups: publicProcedure.input(UpdateResourceRequesterGroupsInput).mutation(async ({ input, ctx }) => {
+    const logger = createStampHubLogger();
+    const result = await updateResourceRequesterGroups({
+      catalogDBProvider: ctx.db.catalogDB,
+      catalogConfigProvider: ctx.config.catalogConfig,
+      resourceDBProvider: ctx.db.resourceDB,
+      getGroupMemberShip: ctx.identity.groupMemberShip.get,
+      getGroup: ctx.identity.group.get,
+    })(input).mapErr(convertTRPCError(logger));
+    return unwrapOrthrowTRPCError(result);
+  }),
+  updateVisibility: publicProcedure.input(UpdateResourceVisibilityInput).mutation(async ({ input, ctx }) => {
+    const logger = createStampHubLogger();
+    const result = await updateResourceVisibility({
+      catalogDBProvider: ctx.db.catalogDB,
+      catalogConfigProvider: ctx.config.catalogConfig,
+      resourceDBProvider: ctx.db.resourceDB,
+      getGroupMemberShip: ctx.identity.groupMemberShip.get,
+    })(input).mapErr(convertTRPCError(logger));
+    return unwrapOrthrowTRPCError(result);
   }),
   listAuditItem: publicProcedure.input(ListResourceAuditItemInput).query(async ({ input, ctx }) => {
     const logger = createStampHubLogger();

--- a/packages/hub/src/system-catalog/index.test.ts
+++ b/packages/hub/src/system-catalog/index.test.ts
@@ -11,6 +11,7 @@ describe("createStampSystemCatalog", () => {
       createAuditNotification: vi.fn(),
       updateAuditNotification: vi.fn(),
       deleteAuditNotification: vi.fn(),
+      listByResourceType: vi.fn(),
     };
     const catalogConfigProvider = {
       get: vi.fn(),

--- a/packages/hub/src/workflows/approval-request/revoke.test.ts
+++ b/packages/hub/src/workflows/approval-request/revoke.test.ts
@@ -148,6 +148,7 @@ describe("revokeWorkflow", () => {
     createAuditNotification: vi.fn().mockResolvedValue(err(new DBError("DB error"))),
     updateAuditNotification: vi.fn().mockResolvedValue(err(new DBError("DB error"))),
     deleteAuditNotification: vi.fn().mockResolvedValue(err(new DBError("DB error"))),
+    listByResourceType: vi.fn(),
   };
 
   const groupMemberShipProvider: GroupMemberShipProvider = {

--- a/packages/hub/src/workflows/approval-request/submit.ts
+++ b/packages/hub/src/workflows/approval-request/submit.ts
@@ -19,7 +19,8 @@ import { validateAutoRevokeDurationTime } from "../../events/approval-request/ac
 import { CreateSchedulerEvent } from "@stamp-lib/stamp-types/pluginInterface/scheduler";
 import type { CatalogConfig, ApprovalFlowConfig } from "@stamp-lib/stamp-types/models";
 
-export const SubmitWorkflowInput = SubmittedRequest.omit({ requestId: true, status: true, requestDate: true }).extend({
+// visibility is computed by the hub at submit time and must not be supplied by the caller.
+export const SubmitWorkflowInput = SubmittedRequest.omit({ requestId: true, status: true, requestDate: true, visibility: true }).extend({
   approverType: ApproverType.optional(),
   approverId: z.string().uuid().optional(),
 });

--- a/packages/hub/src/workflows/resource/cancelUpdateResourceParamsWithApproval.test.ts
+++ b/packages/hub/src/workflows/resource/cancelUpdateResourceParamsWithApproval.test.ts
@@ -49,6 +49,7 @@ describe("cancelUpdateResourceWithApproval", () => {
       createAuditNotification: vi.fn(),
       updateAuditNotification: vi.fn(),
       deleteAuditNotification: vi.fn(),
+      listByResourceType: vi.fn(),
     };
     const canceledRequest = {
       ...approvalRequest,
@@ -106,6 +107,7 @@ describe("cancelUpdateResourceWithApproval", () => {
       createAuditNotification: vi.fn(),
       updateAuditNotification: vi.fn(),
       deleteAuditNotification: vi.fn(),
+      listByResourceType: vi.fn(),
     };
     const approvalRequestDBProvider = {
       getById: vi.fn(),
@@ -148,6 +150,7 @@ describe("cancelUpdateResourceWithApproval", () => {
       createAuditNotification: vi.fn(),
       updateAuditNotification: vi.fn(),
       deleteAuditNotification: vi.fn(),
+      listByResourceType: vi.fn(),
     };
     const approvalRequestDBProvider = {
       getById: vi.fn(),
@@ -188,6 +191,7 @@ describe("cancelUpdateResourceWithApproval", () => {
       createAuditNotification: vi.fn(),
       updateAuditNotification: vi.fn(),
       deleteAuditNotification: vi.fn(),
+      listByResourceType: vi.fn(),
     };
     const approvalRequestDBProvider = {
       getById: vi.fn().mockReturnValue(okAsync(none)),
@@ -228,6 +232,7 @@ describe("cancelUpdateResourceWithApproval", () => {
       createAuditNotification: vi.fn(),
       updateAuditNotification: vi.fn(),
       deleteAuditNotification: vi.fn(),
+      listByResourceType: vi.fn(),
     };
     const approvalRequestDBProvider = {
       getById: vi.fn().mockReturnValue(okAsync(some({ ...approvalRequest, status: "approvedActionFailed" }))),
@@ -276,6 +281,7 @@ describe("cancelUpdateResourceWithApproval", () => {
       createAuditNotification: vi.fn(),
       updateAuditNotification: vi.fn(),
       deleteAuditNotification: vi.fn(),
+      listByResourceType: vi.fn(),
     };
     const approvalRequestDBProvider = {
       getById: vi.fn().mockReturnValue(okAsync(some({ ...approvalRequest, status: "rejected" }))),
@@ -324,6 +330,7 @@ describe("cancelUpdateResourceWithApproval", () => {
       createAuditNotification: vi.fn(),
       updateAuditNotification: vi.fn(),
       deleteAuditNotification: vi.fn(),
+      listByResourceType: vi.fn(),
     };
     const approvalRequestDBProvider = {
       getById: vi.fn().mockReturnValue(okAsync(some({ ...approvalRequest, status: "approved" }))),
@@ -364,6 +371,7 @@ describe("cancelUpdateResourceWithApproval", () => {
       createAuditNotification: vi.fn(),
       updateAuditNotification: vi.fn(),
       deleteAuditNotification: vi.fn(),
+      listByResourceType: vi.fn(),
     };
     const approvalRequestDBProvider = {
       getById: vi.fn().mockReturnValue(okAsync(some(approvalRequest))),

--- a/packages/hub/src/workflows/resource/createResource.test.ts
+++ b/packages/hub/src/workflows/resource/createResource.test.ts
@@ -310,4 +310,77 @@ describe("createResource", () => {
     expect(result.error.userMessage).toBe("ResourceType Not Found");
     expect(result.error.code).toBe("NOT_FOUND");
   });
+  it("Adds record to resource DB when only requesterGroupIds is given (normalized, deduped)", async () => {
+    const requesterGroupId = "1f10d463-a2fe-c407-2b95-05b561346c8b";
+    const input: CreateResourceInput = {
+      ...baseInput,
+      parentResourceId: "123456789012",
+      requesterGroupIds: [requesterGroupId, requesterGroupId],
+    };
+    const catalogConfig: CatalogConfig = { ...baseCatalogConfig, resourceTypes: [resourceTypeConfigForSuccess] };
+    const catalogConfigProvider: CatalogConfigProvider = { get: () => okAsync(some(catalogConfig)) };
+    const set = vi.fn((resourceOnDB: ResourceOnDB) => okAsync(structuredClone(resourceOnDB)));
+
+    const result = await createResource({
+      catalogDBProvider: catalogDbProviderForSuccess,
+      catalogConfigProvider: catalogConfigProvider,
+      resourceDBProvider: { ...resourceDBProviderForSuccess, set },
+      getGroupMemberShip: groupMemberShipProvider.get,
+    })(input);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(set).toHaveBeenCalledTimes(1);
+    expect(set.mock.calls[0][0]).toMatchObject({ id: "112233445566", requesterGroupIds: [requesterGroupId], visibility: undefined });
+    expect(result.value.requesterGroupIds).toEqual([requesterGroupId]);
+  });
+
+  it("Adds record to resource DB when only visibility restricted is given", async () => {
+    const input: CreateResourceInput = {
+      ...baseInput,
+      parentResourceId: "123456789012",
+      visibility: "restricted",
+    };
+    const catalogConfig: CatalogConfig = { ...baseCatalogConfig, resourceTypes: [resourceTypeConfigForSuccess] };
+    const catalogConfigProvider: CatalogConfigProvider = { get: () => okAsync(some(catalogConfig)) };
+    const set = vi.fn((resourceOnDB: ResourceOnDB) => okAsync(structuredClone(resourceOnDB)));
+
+    const result = await createResource({
+      catalogDBProvider: catalogDbProviderForSuccess,
+      catalogConfigProvider: catalogConfigProvider,
+      resourceDBProvider: { ...resourceDBProviderForSuccess, set },
+      getGroupMemberShip: groupMemberShipProvider.get,
+    })(input);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(set).toHaveBeenCalledTimes(1);
+    expect(set.mock.calls[0][0]).toMatchObject({ id: "112233445566", visibility: "restricted" });
+    expect(result.value.visibility).toBe("restricted");
+  });
+
+  it('Does not add record to resource DB when requesterGroupIds is [] and visibility is "all"', async () => {
+    const input: CreateResourceInput = {
+      ...baseInput,
+      parentResourceId: "123456789012",
+      requesterGroupIds: [],
+      visibility: "all",
+    };
+    const catalogConfig: CatalogConfig = { ...baseCatalogConfig, resourceTypes: [resourceTypeConfigForSuccess] };
+    const catalogConfigProvider: CatalogConfigProvider = { get: () => okAsync(some(catalogConfig)) };
+    const set = vi.fn((resourceOnDB: ResourceOnDB) => okAsync(structuredClone(resourceOnDB)));
+
+    const result = await createResource({
+      catalogDBProvider: catalogDbProviderForSuccess,
+      catalogConfigProvider: catalogConfigProvider,
+      resourceDBProvider: { ...resourceDBProviderForSuccess, set },
+      getGroupMemberShip: groupMemberShipProvider.get,
+    })(input);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(set).not.toHaveBeenCalled();
+    expect(result.value.requesterGroupIds).toBeUndefined();
+    expect(result.value.visibility).toBeUndefined();
+  });
 });

--- a/packages/hub/src/workflows/resource/createResource.ts
+++ b/packages/hub/src/workflows/resource/createResource.ts
@@ -10,6 +10,7 @@ import { createGetCatalogConfig } from "../../events/catalog/catalogConfig";
 import { getResourceTypeConfig } from "../../events/resource-type/resourceTypeConfig";
 import { createCheckCanCreateResource } from "../../events/resource/authz/canCreateResource";
 import { convertPromiseResultToResultAsync, parseZodObject } from "../../utils/neverthrow";
+import { normalizeRequesterGroupIds, normalizeVisibility } from "./normalizeResourceAccessSettings";
 
 export const createResource =
   (providers: {
@@ -49,11 +50,13 @@ export const createResource =
           );
         })
         .andThen((resource) => {
-          if (!parsedInput.approverGroupId && !parsedInput.ownerGroupId) {
-            // If approverGroupId and ownerGroupId are undefined, do not register to DB. (e.g. Unicorn)
-            return okAsync({ id: resource.resourceId, ...parsedInput, ...resource });
+          const requesterGroupIds = normalizeRequesterGroupIds(parsedInput.requesterGroupIds);
+          const visibility = normalizeVisibility(parsedInput.visibility);
+          if (!parsedInput.approverGroupId && !parsedInput.ownerGroupId && requesterGroupIds === undefined && visibility === undefined) {
+            // If no hub-side setting is given, do not register to DB. (e.g. Unicorn)
+            return okAsync({ id: resource.resourceId, ...parsedInput, requesterGroupIds, visibility, ...resource });
           }
-          return resourceDBProvider.set({ ...parsedInput, id: resource.resourceId }).map((resourceOnDB) => {
+          return resourceDBProvider.set({ ...parsedInput, requesterGroupIds, visibility, id: resource.resourceId }).map((resourceOnDB) => {
             return { ...resourceOnDB, ...resource };
           });
         })

--- a/packages/hub/src/workflows/resource/deleteResource.test.ts
+++ b/packages/hub/src/workflows/resource/deleteResource.test.ts
@@ -75,6 +75,7 @@ describe("deleteResource", () => {
     createAuditNotification: vi.fn(),
     updateAuditNotification: vi.fn(),
     deleteAuditNotification: vi.fn(),
+    listByResourceType: vi.fn(),
   };
 
   const mockGetGroupMemberShip = vi.fn().mockReturnValue(okAsync(some({})));

--- a/packages/hub/src/workflows/resource/input.ts
+++ b/packages/hub/src/workflows/resource/input.ts
@@ -1,4 +1,4 @@
-import { CatalogId, ResourceId, ResourceParams, ResourceTypeId } from "@stamp-lib/stamp-types/models";
+import { CatalogId, RequesterGroupIds, ResourceId, ResourceParams, ResourceTypeId, ResourceVisibility } from "@stamp-lib/stamp-types/models";
 import { GroupId, UserId } from "@stamp-lib/stamp-types/pluginInterface/identity";
 import { z } from "zod";
 
@@ -17,6 +17,8 @@ export const CreateResourceInput = z.object({
   parentResourceId: ResourceId.optional(),
   approverGroupId: GroupId.optional(),
   ownerGroupId: GroupId.optional(),
+  requesterGroupIds: RequesterGroupIds.optional(),
+  visibility: ResourceVisibility.optional(),
   requestUserId: UserId,
 });
 export type CreateResourceInput = z.infer<typeof CreateResourceInput>;
@@ -83,6 +85,24 @@ export const UpdateResourceOwnerInput = z.object({
   requestUserId: UserId,
 });
 export type UpdateResourceOwnerInput = z.infer<typeof UpdateResourceOwnerInput>;
+
+export const UpdateResourceRequesterGroupsInput = z.object({
+  catalogId: CatalogId,
+  resourceTypeId: ResourceTypeId,
+  resourceId: ResourceId,
+  requesterGroupIds: RequesterGroupIds, // Empty array clears the restriction (anyone can request).
+  requestUserId: UserId,
+});
+export type UpdateResourceRequesterGroupsInput = z.infer<typeof UpdateResourceRequesterGroupsInput>;
+
+export const UpdateResourceVisibilityInput = z.object({
+  catalogId: CatalogId,
+  resourceTypeId: ResourceTypeId,
+  resourceId: ResourceId,
+  visibility: ResourceVisibility,
+  requestUserId: UserId,
+});
+export type UpdateResourceVisibilityInput = z.infer<typeof UpdateResourceVisibilityInput>;
 
 export const ListResourceAuditItemInput = z.object({
   catalogId: CatalogId,

--- a/packages/hub/src/workflows/resource/normalizeResourceAccessSettings.test.ts
+++ b/packages/hub/src/workflows/resource/normalizeResourceAccessSettings.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { normalizeRequesterGroupIds, normalizeVisibility } from "./normalizeResourceAccessSettings";
+
+const a = "1f10d463-a2fe-c407-2b95-05b561346c8b";
+const b = "7c2b9e4d-1a3f-4c5e-9b8a-6d5c4b3a2f1e";
+
+describe("normalizeRequesterGroupIds", () => {
+  it("returns undefined for undefined", () => {
+    expect(normalizeRequesterGroupIds(undefined)).toBeUndefined();
+  });
+  it("returns undefined for an empty array", () => {
+    expect(normalizeRequesterGroupIds([])).toBeUndefined();
+  });
+  it("dedupes while keeping order", () => {
+    expect(normalizeRequesterGroupIds([a, b, a])).toEqual([a, b]);
+  });
+});
+
+describe("normalizeVisibility", () => {
+  it('returns undefined for undefined and "all"', () => {
+    expect(normalizeVisibility(undefined)).toBeUndefined();
+    expect(normalizeVisibility("all")).toBeUndefined();
+  });
+  it('keeps "restricted"', () => {
+    expect(normalizeVisibility("restricted")).toBe("restricted");
+  });
+});

--- a/packages/hub/src/workflows/resource/normalizeResourceAccessSettings.ts
+++ b/packages/hub/src/workflows/resource/normalizeResourceAccessSettings.ts
@@ -1,0 +1,20 @@
+import { RequesterGroupIds, ResourceVisibility } from "@stamp-lib/stamp-types/models";
+
+/**
+ * Dedupe requester group ids. An empty array is normalized to `undefined`
+ * so that the DB attribute is removed instead of storing an empty list.
+ */
+export function normalizeRequesterGroupIds(requesterGroupIds: RequesterGroupIds | undefined): RequesterGroupIds | undefined {
+  if (requesterGroupIds === undefined) {
+    return undefined;
+  }
+  const unique = Array.from(new Set(requesterGroupIds));
+  return unique.length === 0 ? undefined : unique;
+}
+
+/**
+ * "all" is the default visibility and is stored as `undefined`.
+ */
+export function normalizeVisibility(visibility: ResourceVisibility | undefined): ResourceVisibility | undefined {
+  return visibility === "restricted" ? "restricted" : undefined;
+}

--- a/packages/hub/src/workflows/resource/updateResourceParamsWithApproval/execution.test.ts
+++ b/packages/hub/src/workflows/resource/updateResourceParamsWithApproval/execution.test.ts
@@ -28,6 +28,7 @@ describe("updateResourceParamsWithApproval.execution", () => {
     createAuditNotification: vi.fn(),
     updateAuditNotification: vi.fn(),
     deleteAuditNotification: vi.fn(),
+    listByResourceType: vi.fn(),
   });
 
   // Create logger using the actual createLogger function

--- a/packages/hub/src/workflows/resource/updateResourceParamsWithApproval/resolution.test.ts
+++ b/packages/hub/src/workflows/resource/updateResourceParamsWithApproval/resolution.test.ts
@@ -26,6 +26,7 @@ describe("updateResourceParamsWithApproval.resolution", () => {
         createAuditNotification: vi.fn(),
         updateAuditNotification: vi.fn(),
         deleteAuditNotification: vi.fn(),
+        listByResourceType: vi.fn(),
       };
       const mockGetResourceInfo = vi.fn().mockReturnValue(okAsync(some({ id: "res-1", name: "Test Resource" })));
 

--- a/packages/hub/src/workflows/resource/updateResourceRequesterGroups.test.ts
+++ b/packages/hub/src/workflows/resource/updateResourceRequesterGroups.test.ts
@@ -1,0 +1,262 @@
+import { none, some } from "@stamp-lib/stamp-option";
+import { HandlerError, ResourceHandlers } from "@stamp-lib/stamp-types/catalogInterface/handler";
+import { CatalogConfigProvider } from "@stamp-lib/stamp-types/configInterface";
+import { CatalogConfig, ResourceOnDB, ResourceTypeConfig } from "@stamp-lib/stamp-types/models";
+import { CatalogDBProvider, DBError, ResourceDBProvider, ResourceInput } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { GetGroup, GroupMemberShipProvider, IdentityPluginError } from "@stamp-lib/stamp-types/pluginInterface/identity";
+import { err, ok, okAsync } from "neverthrow";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { UpdateResourceRequesterGroupsInput } from "./input";
+import { updateResourceRequesterGroups } from "./updateResourceRequesterGroups";
+
+const requestUserId = "47f29c51-204c-09f6-2069-f3df073568c7"; // uuid is meaningless and was generated for testing.
+const catalogOwnerGroupId = "0a3d8d5b-7a3f-4b2e-9c1d-2f4e6a8b0c1d";
+const resourceOwnerGroupId = "96fc6a4c-b5d3-8c2b-0307-165168a023cd";
+const parentOwnerGroupId = "5e8f1c2a-3b4d-4e5f-8a9b-0c1d2e3f4a5b";
+const requesterGroupA = "1f10d463-a2fe-c407-2b95-05b561346c8b";
+const requesterGroupB = "7c2b9e4d-1a3f-4c5e-9b8a-6d5c4b3a2f1e";
+const unknownGroupId = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+
+const resourceId = "112233445566";
+const parentResourceId = "123456789012";
+const catalogId = "test-catalog-id";
+const resourceTypeId = "test-resource-type-id";
+const parentResourceTypeId = "test-parent-resource-type-id";
+
+const testResourceHandler: ResourceHandlers = {
+  createResource: async () => err(new HandlerError("not implemented", "INTERNAL_SERVER_ERROR")),
+  deleteResource: async () => err(new HandlerError("not implemented", "INTERNAL_SERVER_ERROR")),
+  getResource: async () => ok(some({ params: {}, resourceId, name: "test-resource", parentResourceId })),
+  listResources: async () => err(new HandlerError("not implemented", "INTERNAL_SERVER_ERROR")),
+  updateResource: async () => err(new HandlerError("not implemented", "INTERNAL_SERVER_ERROR")),
+  listResourceAuditItem: async () => err(new HandlerError("not implemented", "INTERNAL_SERVER_ERROR")),
+};
+
+const resourceTypeConfig: ResourceTypeConfig = {
+  id: resourceTypeId,
+  name: "test resource type",
+  description: "test resource type",
+  createParams: [],
+  infoParams: [],
+  handlers: testResourceHandler,
+  isCreatable: false,
+  isUpdatable: false,
+  isDeletable: false,
+  ownerManagement: true,
+  approverManagement: true,
+  parentResourceTypeId,
+};
+
+const catalogConfig: CatalogConfig = {
+  id: catalogId,
+  name: "test-catalog-name",
+  description: "test-description",
+  approvalFlows: [],
+  resourceTypes: [resourceTypeConfig],
+};
+
+const catalogConfigProvider: CatalogConfigProvider = {
+  get: () => okAsync(some(catalogConfig)),
+};
+
+const catalogDBProvider: CatalogDBProvider = {
+  getById: () => okAsync(some({ id: catalogId, ownerGroupId: catalogOwnerGroupId })),
+  listAll: vi.fn().mockResolvedValue(err(new DBError("DB error"))),
+  set: vi.fn().mockResolvedValue(err(new DBError("DB error"))),
+  delete: vi.fn().mockResolvedValue(err(new DBError("DB error"))),
+};
+
+const existingResourceOnDB: ResourceOnDB = {
+  id: resourceId,
+  catalogId,
+  resourceTypeId,
+  ownerGroupId: resourceOwnerGroupId,
+  approverGroupId: undefined,
+};
+
+function createResourceDBProvider(resourceRow: ResourceOnDB | undefined) {
+  const set = vi.fn((resourceOnDB: ResourceOnDB) => okAsync(structuredClone(resourceOnDB)));
+  const provider: ResourceDBProvider = {
+    getById: vi.fn((input: ResourceInput) => {
+      if (input.resourceTypeId === parentResourceTypeId && input.id === parentResourceId) {
+        return okAsync(some({ id: parentResourceId, catalogId, resourceTypeId: parentResourceTypeId, ownerGroupId: parentOwnerGroupId }));
+      }
+      return okAsync(resourceRow === undefined ? none : some(structuredClone(resourceRow)));
+    }),
+    set,
+    updatePendingUpdateParams: vi.fn(),
+    delete: vi.fn(),
+    createAuditNotification: vi.fn(),
+    updateAuditNotification: vi.fn(),
+    deleteAuditNotification: vi.fn(),
+    listByResourceType: vi.fn(),
+  };
+  return { provider, set };
+}
+
+function createGroupMemberShip(memberOf: Array<string>): GroupMemberShipProvider["get"] {
+  return vi.fn(({ groupId, userId }) =>
+    okAsync(memberOf.includes(groupId) ? some({ groupId, userId, role: "member" as const, createdAt: "", updatedAt: "" }) : none)
+  );
+}
+
+const existingGroups = [catalogOwnerGroupId, resourceOwnerGroupId, parentOwnerGroupId, requesterGroupA, requesterGroupB];
+const getGroup: GetGroup = vi.fn(({ groupId }) =>
+  okAsync(
+    existingGroups.includes(groupId)
+      ? some({ groupId, groupName: "g", description: "", createdAt: "", updatedAt: "" })
+      : none
+  )
+);
+
+const baseInput: UpdateResourceRequesterGroupsInput = {
+  catalogId,
+  resourceTypeId,
+  resourceId,
+  requesterGroupIds: [requesterGroupA, requesterGroupB],
+  requestUserId,
+};
+
+describe("updateResourceRequesterGroups", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ["Catalog Owner", [catalogOwnerGroupId]],
+    ["Resource Owner", [resourceOwnerGroupId]],
+    ["Parent Resource Owner", [parentOwnerGroupId]],
+  ])("%s can set requesterGroupIds", async (_label, memberOf) => {
+    const { provider, set } = createResourceDBProvider(existingResourceOnDB);
+    const result = await updateResourceRequesterGroups({
+      catalogDBProvider,
+      catalogConfigProvider,
+      resourceDBProvider: provider,
+      getGroupMemberShip: createGroupMemberShip(memberOf),
+      getGroup,
+    })(baseInput);
+    if (result.isErr()) throw result.error;
+    expect(set).toHaveBeenCalledTimes(1);
+    expect(set).toHaveBeenCalledWith({ ...existingResourceOnDB, requesterGroupIds: [requesterGroupA, requesterGroupB] });
+    expect(result.value.requesterGroupIds).toEqual([requesterGroupA, requesterGroupB]);
+  });
+
+  it("returns FORBIDDEN for a user who is not catalog owner / resource owner / parent owner", async () => {
+    const { provider, set } = createResourceDBProvider(existingResourceOnDB);
+    const result = await updateResourceRequesterGroups({
+      catalogDBProvider,
+      catalogConfigProvider,
+      resourceDBProvider: provider,
+      getGroupMemberShip: createGroupMemberShip([requesterGroupA]),
+      getGroup,
+    })(baseInput);
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) throw new Error("expected error");
+    expect(result.error.code).toBe("FORBIDDEN");
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("clears the restriction when an empty array is given (stored as undefined)", async () => {
+    const { provider, set } = createResourceDBProvider({ ...existingResourceOnDB, requesterGroupIds: [requesterGroupA] });
+    const result = await updateResourceRequesterGroups({
+      catalogDBProvider,
+      catalogConfigProvider,
+      resourceDBProvider: provider,
+      getGroupMemberShip: createGroupMemberShip([resourceOwnerGroupId]),
+      getGroup,
+    })({ ...baseInput, requesterGroupIds: [] });
+    if (result.isErr()) throw result.error;
+    expect(set).toHaveBeenCalledWith({ ...existingResourceOnDB, requesterGroupIds: undefined });
+    expect(getGroup).not.toHaveBeenCalled();
+  });
+
+  it("dedupes requesterGroupIds", async () => {
+    const { provider, set } = createResourceDBProvider(existingResourceOnDB);
+    const result = await updateResourceRequesterGroups({
+      catalogDBProvider,
+      catalogConfigProvider,
+      resourceDBProvider: provider,
+      getGroupMemberShip: createGroupMemberShip([resourceOwnerGroupId]),
+      getGroup,
+    })({ ...baseInput, requesterGroupIds: [requesterGroupA, requesterGroupA, requesterGroupB] });
+    if (result.isErr()) throw result.error;
+    expect(set).toHaveBeenCalledWith({ ...existingResourceOnDB, requesterGroupIds: [requesterGroupA, requesterGroupB] });
+  });
+
+  it("creates a skeleton row when the resource has no DB row yet", async () => {
+    const { provider, set } = createResourceDBProvider(undefined);
+    const result = await updateResourceRequesterGroups({
+      catalogDBProvider,
+      catalogConfigProvider,
+      resourceDBProvider: provider,
+      getGroupMemberShip: createGroupMemberShip([catalogOwnerGroupId]),
+      getGroup,
+    })({ ...baseInput, requesterGroupIds: [requesterGroupA] });
+    if (result.isErr()) throw result.error;
+    expect(set).toHaveBeenCalledWith({ id: resourceId, catalogId, resourceTypeId, requesterGroupIds: [requesterGroupA] });
+  });
+
+  it("returns BAD_REQUEST when more than 10 groups are given", async () => {
+    const { provider, set } = createResourceDBProvider(existingResourceOnDB);
+    const tooMany = Array.from({ length: 11 }, (_, i) => `00000000-0000-4000-8000-${String(i).padStart(12, "0")}`);
+    const result = await updateResourceRequesterGroups({
+      catalogDBProvider,
+      catalogConfigProvider,
+      resourceDBProvider: provider,
+      getGroupMemberShip: createGroupMemberShip([catalogOwnerGroupId]),
+      getGroup,
+    })({ ...baseInput, requesterGroupIds: tooMany });
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) throw new Error("expected error");
+    expect(result.error.code).toBe("BAD_REQUEST");
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("returns BAD_REQUEST when a group does not exist", async () => {
+    const { provider, set } = createResourceDBProvider(existingResourceOnDB);
+    const result = await updateResourceRequesterGroups({
+      catalogDBProvider,
+      catalogConfigProvider,
+      resourceDBProvider: provider,
+      getGroupMemberShip: createGroupMemberShip([catalogOwnerGroupId]),
+      getGroup,
+    })({ ...baseInput, requesterGroupIds: [requesterGroupA, unknownGroupId] });
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) throw new Error("expected error");
+    expect(result.error.code).toBe("BAD_REQUEST");
+    expect(result.error.userMessage).toContain(unknownGroupId);
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("returns BAD_REQUEST when the resource does not exist in the catalog", async () => {
+    const missingHandler: ResourceHandlers = { ...testResourceHandler, getResource: async () => ok(none) };
+    const provider: CatalogConfigProvider = {
+      get: () => okAsync(some({ ...catalogConfig, resourceTypes: [{ ...resourceTypeConfig, handlers: missingHandler }] })),
+    };
+    const { provider: resourceDBProvider, set } = createResourceDBProvider(existingResourceOnDB);
+    const result = await updateResourceRequesterGroups({
+      catalogDBProvider,
+      catalogConfigProvider: provider,
+      resourceDBProvider,
+      getGroupMemberShip: createGroupMemberShip([catalogOwnerGroupId]),
+      getGroup,
+    })(baseInput);
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) throw new Error("expected error");
+    expect(result.error.code).toBe("BAD_REQUEST");
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("propagates identity provider errors as StampHubError", async () => {
+    const { provider } = createResourceDBProvider(existingResourceOnDB);
+    const failingGetGroup: GetGroup = vi.fn(() => err(new IdentityPluginError("identity error")) as unknown as ReturnType<GetGroup>);
+    const result = await updateResourceRequesterGroups({
+      catalogDBProvider,
+      catalogConfigProvider,
+      resourceDBProvider: provider,
+      getGroupMemberShip: createGroupMemberShip([catalogOwnerGroupId]),
+      getGroup: failingGetGroup,
+    })(baseInput);
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/hub/src/workflows/resource/updateResourceRequesterGroups.ts
+++ b/packages/hub/src/workflows/resource/updateResourceRequesterGroups.ts
@@ -1,0 +1,71 @@
+import { CatalogConfigProvider } from "@stamp-lib/stamp-types/configInterface";
+import { ResourceOnDB } from "@stamp-lib/stamp-types/models";
+import { CatalogDBProvider, ResourceDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { GetGroup, GroupId, GroupMemberShipProvider } from "@stamp-lib/stamp-types/pluginInterface/identity";
+import { ResultAsync, errAsync, okAsync } from "neverthrow";
+import { StampHubError, convertStampHubError } from "../../error";
+import { createGetCatalogConfig } from "../../events/catalog/catalogConfig";
+import { getResourceTypeConfig } from "../../events/resource-type/resourceTypeConfig";
+import { createCheckCanEditResource } from "../../events/resource/authz/canEditResource";
+import { parseZodObject } from "../../utils/neverthrow";
+import { UpdateResourceRequesterGroupsInput } from "./input";
+import { normalizeRequesterGroupIds } from "./normalizeResourceAccessSettings";
+
+/**
+ * Set the groups whose members may submit approval requests for the resource.
+ * Allowed for Catalog Owner / Resource Owner / Parent Resource Owner (same as other resource edits).
+ * An empty array clears the restriction.
+ */
+export const updateResourceRequesterGroups =
+  (providers: {
+    catalogDBProvider: CatalogDBProvider;
+    catalogConfigProvider: CatalogConfigProvider;
+    resourceDBProvider: ResourceDBProvider;
+    getGroupMemberShip: GroupMemberShipProvider["get"];
+    getGroup: GetGroup;
+  }) =>
+  (input: UpdateResourceRequesterGroupsInput): ResultAsync<ResourceOnDB, StampHubError> => {
+    const { catalogDBProvider, catalogConfigProvider, resourceDBProvider, getGroupMemberShip, getGroup } = providers;
+    const getCatalogConfig = createGetCatalogConfig(catalogConfigProvider.get);
+    const checkCanEditResource = createCheckCanEditResource(catalogDBProvider.getById, catalogConfigProvider.get, resourceDBProvider.getById, getGroupMemberShip);
+
+    const parsedInputResult = parseZodObject(input, UpdateResourceRequesterGroupsInput);
+    if (parsedInputResult.isErr()) {
+      return errAsync(parsedInputResult.error);
+    }
+    const parsedInput = parsedInputResult.value;
+    const requesterGroupIds = normalizeRequesterGroupIds(parsedInput.requesterGroupIds);
+
+    const validateGroupsExist = (groupIds: Array<GroupId>): ResultAsync<void, StampHubError> => {
+      return ResultAsync.combine(groupIds.map((groupId) => getGroup({ groupId }).map((group) => ({ groupId, exists: group.isSome() }))))
+        .mapErr(convertStampHubError)
+        .andThen((results) => {
+          const missing = results.filter((r) => !r.exists).map((r) => r.groupId);
+          if (missing.length > 0) {
+            return errAsync(new StampHubError(`Group not found: ${missing.join(", ")}`, `Group not found: ${missing.join(", ")}`, "BAD_REQUEST"));
+          }
+          return okAsync(undefined);
+        });
+    };
+
+    return getCatalogConfig(parsedInput)
+      .andThen(checkCanEditResource)
+      .andThen(getResourceTypeConfig)
+      .andThen((extendInput) => validateGroupsExist(requesterGroupIds ?? []).map(() => extendInput))
+      .andThen((extendInput) => {
+        return resourceDBProvider
+          .getById({
+            id: parsedInput.resourceId,
+            catalogId: parsedInput.catalogId,
+            resourceTypeId: extendInput.resourceTypeConfig.id,
+          })
+          .map((resource): ResourceOnDB => {
+            if (resource.isNone()) {
+              return { id: extendInput.resourceId, catalogId: extendInput.catalogId, resourceTypeId: extendInput.resourceTypeId };
+            }
+            return resource.value;
+          });
+      })
+      .andThen((resource) => resourceDBProvider.set({ ...resource, requesterGroupIds }))
+      .mapErr(convertStampHubError);
+  };

--- a/packages/hub/src/workflows/resource/updateResourceVisibility.test.ts
+++ b/packages/hub/src/workflows/resource/updateResourceVisibility.test.ts
@@ -1,0 +1,201 @@
+import { none, some } from "@stamp-lib/stamp-option";
+import { HandlerError, ResourceHandlers } from "@stamp-lib/stamp-types/catalogInterface/handler";
+import { CatalogConfigProvider } from "@stamp-lib/stamp-types/configInterface";
+import { CatalogConfig, ResourceOnDB, ResourceTypeConfig } from "@stamp-lib/stamp-types/models";
+import { CatalogDBProvider, DBError, ResourceDBProvider, ResourceInput } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { GroupMemberShipProvider } from "@stamp-lib/stamp-types/pluginInterface/identity";
+import { err, ok, okAsync } from "neverthrow";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { UpdateResourceVisibilityInput } from "./input";
+import { updateResourceVisibility } from "./updateResourceVisibility";
+
+const requestUserId = "47f29c51-204c-09f6-2069-f3df073568c7"; // uuid is meaningless and was generated for testing.
+const catalogOwnerGroupId = "0a3d8d5b-7a3f-4b2e-9c1d-2f4e6a8b0c1d";
+const resourceOwnerGroupId = "96fc6a4c-b5d3-8c2b-0307-165168a023cd";
+const parentOwnerGroupId = "5e8f1c2a-3b4d-4e5f-8a9b-0c1d2e3f4a5b";
+const otherGroupId = "1f10d463-a2fe-c407-2b95-05b561346c8b";
+
+const resourceId = "112233445566";
+const parentResourceId = "123456789012";
+const catalogId = "test-catalog-id";
+const resourceTypeId = "test-resource-type-id";
+const parentResourceTypeId = "test-parent-resource-type-id";
+
+const testResourceHandler: ResourceHandlers = {
+  createResource: async () => err(new HandlerError("not implemented", "INTERNAL_SERVER_ERROR")),
+  deleteResource: async () => err(new HandlerError("not implemented", "INTERNAL_SERVER_ERROR")),
+  getResource: async () => ok(some({ params: {}, resourceId, name: "test-resource", parentResourceId })),
+  listResources: async () => err(new HandlerError("not implemented", "INTERNAL_SERVER_ERROR")),
+  updateResource: async () => err(new HandlerError("not implemented", "INTERNAL_SERVER_ERROR")),
+  listResourceAuditItem: async () => err(new HandlerError("not implemented", "INTERNAL_SERVER_ERROR")),
+};
+
+const resourceTypeConfig: ResourceTypeConfig = {
+  id: resourceTypeId,
+  name: "test resource type",
+  description: "test resource type",
+  createParams: [],
+  infoParams: [],
+  handlers: testResourceHandler,
+  isCreatable: false,
+  isUpdatable: false,
+  isDeletable: false,
+  ownerManagement: true,
+  approverManagement: true,
+  parentResourceTypeId,
+};
+
+const catalogConfig: CatalogConfig = {
+  id: catalogId,
+  name: "test-catalog-name",
+  description: "test-description",
+  approvalFlows: [],
+  resourceTypes: [resourceTypeConfig],
+};
+
+const catalogConfigProvider: CatalogConfigProvider = {
+  get: () => okAsync(some(catalogConfig)),
+};
+
+const catalogDBProvider: CatalogDBProvider = {
+  getById: () => okAsync(some({ id: catalogId, ownerGroupId: catalogOwnerGroupId })),
+  listAll: vi.fn().mockResolvedValue(err(new DBError("DB error"))),
+  set: vi.fn().mockResolvedValue(err(new DBError("DB error"))),
+  delete: vi.fn().mockResolvedValue(err(new DBError("DB error"))),
+};
+
+const existingResourceOnDB: ResourceOnDB = {
+  id: resourceId,
+  catalogId,
+  resourceTypeId,
+  ownerGroupId: resourceOwnerGroupId,
+  approverGroupId: undefined,
+};
+
+function createResourceDBProvider(resourceRow: ResourceOnDB | undefined) {
+  const set = vi.fn((resourceOnDB: ResourceOnDB) => okAsync(structuredClone(resourceOnDB)));
+  const provider: ResourceDBProvider = {
+    getById: vi.fn((input: ResourceInput) => {
+      if (input.resourceTypeId === parentResourceTypeId && input.id === parentResourceId) {
+        return okAsync(some({ id: parentResourceId, catalogId, resourceTypeId: parentResourceTypeId, ownerGroupId: parentOwnerGroupId }));
+      }
+      return okAsync(resourceRow === undefined ? none : some(structuredClone(resourceRow)));
+    }),
+    set,
+    updatePendingUpdateParams: vi.fn(),
+    delete: vi.fn(),
+    createAuditNotification: vi.fn(),
+    updateAuditNotification: vi.fn(),
+    deleteAuditNotification: vi.fn(),
+    listByResourceType: vi.fn(),
+  };
+  return { provider, set };
+}
+
+function createGroupMemberShip(memberOf: Array<string>): GroupMemberShipProvider["get"] {
+  return vi.fn(({ groupId, userId }) =>
+    okAsync(memberOf.includes(groupId) ? some({ groupId, userId, role: "member" as const, createdAt: "", updatedAt: "" }) : none)
+  );
+}
+
+const baseInput: UpdateResourceVisibilityInput = {
+  catalogId,
+  resourceTypeId,
+  resourceId,
+  visibility: "restricted",
+  requestUserId,
+};
+
+describe("updateResourceVisibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ["Catalog Owner", [catalogOwnerGroupId]],
+    ["Resource Owner", [resourceOwnerGroupId]],
+    ["Parent Resource Owner", [parentOwnerGroupId]],
+  ])("%s can set visibility to restricted", async (_label, memberOf) => {
+    const { provider, set } = createResourceDBProvider(existingResourceOnDB);
+    const result = await updateResourceVisibility({
+      catalogDBProvider,
+      catalogConfigProvider,
+      resourceDBProvider: provider,
+      getGroupMemberShip: createGroupMemberShip(memberOf),
+    })(baseInput);
+    if (result.isErr()) throw result.error;
+    expect(set).toHaveBeenCalledTimes(1);
+    expect(set).toHaveBeenCalledWith({ ...existingResourceOnDB, visibility: "restricted" });
+    expect(result.value.visibility).toBe("restricted");
+  });
+
+  it("returns FORBIDDEN for a user who is not catalog owner / resource owner / parent owner", async () => {
+    const { provider, set } = createResourceDBProvider(existingResourceOnDB);
+    const result = await updateResourceVisibility({
+      catalogDBProvider,
+      catalogConfigProvider,
+      resourceDBProvider: provider,
+      getGroupMemberShip: createGroupMemberShip([otherGroupId]),
+    })(baseInput);
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) throw new Error("expected error");
+    expect(result.error.code).toBe("FORBIDDEN");
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it('stores "all" as undefined (default)', async () => {
+    const { provider, set } = createResourceDBProvider({ ...existingResourceOnDB, visibility: "restricted" });
+    const result = await updateResourceVisibility({
+      catalogDBProvider,
+      catalogConfigProvider,
+      resourceDBProvider: provider,
+      getGroupMemberShip: createGroupMemberShip([resourceOwnerGroupId]),
+    })({ ...baseInput, visibility: "all" });
+    if (result.isErr()) throw result.error;
+    expect(set).toHaveBeenCalledWith({ ...existingResourceOnDB, visibility: undefined });
+  });
+
+  it("creates a skeleton row when the resource has no DB row yet", async () => {
+    const { provider, set } = createResourceDBProvider(undefined);
+    const result = await updateResourceVisibility({
+      catalogDBProvider,
+      catalogConfigProvider,
+      resourceDBProvider: provider,
+      getGroupMemberShip: createGroupMemberShip([catalogOwnerGroupId]),
+    })(baseInput);
+    if (result.isErr()) throw result.error;
+    expect(set).toHaveBeenCalledWith({ id: resourceId, catalogId, resourceTypeId, visibility: "restricted" });
+  });
+
+  it("returns BAD_REQUEST for an invalid visibility value", async () => {
+    const { provider, set } = createResourceDBProvider(existingResourceOnDB);
+    const result = await updateResourceVisibility({
+      catalogDBProvider,
+      catalogConfigProvider,
+      resourceDBProvider: provider,
+      getGroupMemberShip: createGroupMemberShip([catalogOwnerGroupId]),
+    })({ ...baseInput, visibility: "public" as unknown as "all" });
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) throw new Error("expected error");
+    expect(result.error.code).toBe("BAD_REQUEST");
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("returns BAD_REQUEST when the resource does not exist in the catalog", async () => {
+    const missingHandler: ResourceHandlers = { ...testResourceHandler, getResource: async () => ok(none) };
+    const provider: CatalogConfigProvider = {
+      get: () => okAsync(some({ ...catalogConfig, resourceTypes: [{ ...resourceTypeConfig, handlers: missingHandler }] })),
+    };
+    const { provider: resourceDBProvider, set } = createResourceDBProvider(existingResourceOnDB);
+    const result = await updateResourceVisibility({
+      catalogDBProvider,
+      catalogConfigProvider: provider,
+      resourceDBProvider,
+      getGroupMemberShip: createGroupMemberShip([catalogOwnerGroupId]),
+    })(baseInput);
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) throw new Error("expected error");
+    expect(result.error.code).toBe("BAD_REQUEST");
+    expect(set).not.toHaveBeenCalled();
+  });
+});

--- a/packages/hub/src/workflows/resource/updateResourceVisibility.ts
+++ b/packages/hub/src/workflows/resource/updateResourceVisibility.ts
@@ -1,0 +1,56 @@
+import { CatalogConfigProvider } from "@stamp-lib/stamp-types/configInterface";
+import { ResourceOnDB } from "@stamp-lib/stamp-types/models";
+import { CatalogDBProvider, ResourceDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { GroupMemberShipProvider } from "@stamp-lib/stamp-types/pluginInterface/identity";
+import { ResultAsync, errAsync } from "neverthrow";
+import { StampHubError, convertStampHubError } from "../../error";
+import { createGetCatalogConfig } from "../../events/catalog/catalogConfig";
+import { getResourceTypeConfig } from "../../events/resource-type/resourceTypeConfig";
+import { createCheckCanEditResource } from "../../events/resource/authz/canEditResource";
+import { parseZodObject } from "../../utils/neverthrow";
+import { UpdateResourceVisibilityInput } from "./input";
+import { normalizeVisibility } from "./normalizeResourceAccessSettings";
+
+/**
+ * Set who can see the resource ("all" | "restricted").
+ * Allowed for Catalog Owner / Resource Owner / Parent Resource Owner (same as other resource edits).
+ */
+export const updateResourceVisibility =
+  (providers: {
+    catalogDBProvider: CatalogDBProvider;
+    catalogConfigProvider: CatalogConfigProvider;
+    resourceDBProvider: ResourceDBProvider;
+    getGroupMemberShip: GroupMemberShipProvider["get"];
+  }) =>
+  (input: UpdateResourceVisibilityInput): ResultAsync<ResourceOnDB, StampHubError> => {
+    const { catalogDBProvider, catalogConfigProvider, resourceDBProvider, getGroupMemberShip } = providers;
+    const getCatalogConfig = createGetCatalogConfig(catalogConfigProvider.get);
+    const checkCanEditResource = createCheckCanEditResource(catalogDBProvider.getById, catalogConfigProvider.get, resourceDBProvider.getById, getGroupMemberShip);
+
+    const parsedInputResult = parseZodObject(input, UpdateResourceVisibilityInput);
+    if (parsedInputResult.isErr()) {
+      return errAsync(parsedInputResult.error);
+    }
+    const parsedInput = parsedInputResult.value;
+    const visibility = normalizeVisibility(parsedInput.visibility);
+
+    return getCatalogConfig(parsedInput)
+      .andThen(checkCanEditResource)
+      .andThen(getResourceTypeConfig)
+      .andThen((extendInput) => {
+        return resourceDBProvider
+          .getById({
+            id: parsedInput.resourceId,
+            catalogId: parsedInput.catalogId,
+            resourceTypeId: extendInput.resourceTypeConfig.id,
+          })
+          .map((resource): ResourceOnDB => {
+            if (resource.isNone()) {
+              return { id: extendInput.resourceId, catalogId: extendInput.catalogId, resourceTypeId: extendInput.resourceTypeId };
+            }
+            return resource.value;
+          });
+      })
+      .andThen((resource) => resourceDBProvider.set({ ...resource, visibility }))
+      .mapErr(convertStampHubError);
+  };

--- a/packages/types/src/models/approvalRequest.ts
+++ b/packages/types/src/models/approvalRequest.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { CatalogId } from "./id";
 import { ApprovalFlowId } from "./id";
-import { UserId } from "../pluginInterface/identity";
+import { UserId, GroupId } from "../pluginInterface/identity";
 import { ResourceId, ResourceName } from "./resource";
 import { ResourceTypeId, ResourceTypeConfig } from "./resourceType";
 import { ApprovalFlowInputParam } from "./approvalFlow";
@@ -40,6 +40,18 @@ export const InputResourceWithName = z.object({
 });
 export type InputResourceWithName = z.infer<typeof InputResourceWithName>;
 
+/**
+ * Visibility snapshot taken when the request is submitted.
+ * Present only if at least one input resource had `visibility: "restricted"` at submit time.
+ * `viewerGroupIds` is the union of the owner / approver / requester / parent-owner groups of those resources.
+ * The visibility of a request is fixed by this snapshot and is not affected by later resource changes or deletion.
+ */
+export const ApprovalRequestVisibility = z.object({
+  type: z.literal("restricted"),
+  viewerGroupIds: z.array(GroupId).max(70),
+});
+export type ApprovalRequestVisibility = z.infer<typeof ApprovalRequestVisibility>;
+
 export const SubmittedRequest = z.object({
   requestId: z.string().uuid(),
   status: z.enum(["submitted"]),
@@ -53,6 +65,7 @@ export const SubmittedRequest = z.object({
   requestDate: z.string().datetime(),
   requestComment: z.string().max(1024),
   autoRevokeDuration: AutoRevokeDuration.optional(),
+  visibility: ApprovalRequestVisibility.optional(),
 });
 export type SubmittedRequest = z.infer<typeof SubmittedRequest>;
 

--- a/packages/types/src/models/resource.ts
+++ b/packages/types/src/models/resource.ts
@@ -33,6 +33,22 @@ export const PendingUpdateParams = z
   .optional();
 export type PendingUpdateParams = z.infer<typeof PendingUpdateParams>;
 
+/**
+ * Groups whose members are allowed to submit approval requests that include this resource.
+ * `undefined` or an empty array means anyone can request.
+ */
+export const RequesterGroupIds = z.array(GroupId).max(10);
+export type RequesterGroupIds = z.infer<typeof RequesterGroupIds>;
+
+/**
+ * Who can see this resource (listOutlines / get / listAuditItem).
+ * - "all" (or `undefined`): everyone.
+ * - "restricted": only members of ownerGroupId / approverGroupId / requesterGroupIds,
+ *   the catalog owner group and the parent resource owner group.
+ */
+export const ResourceVisibility = z.enum(["all", "restricted"]);
+export type ResourceVisibility = z.infer<typeof ResourceVisibility>;
+
 export const ResourceInfo = z.object({
   id: ResourceId,
   name: ResourceName,
@@ -41,6 +57,8 @@ export const ResourceInfo = z.object({
   params: ResourceParams,
   approverGroupId: GroupId.optional(),
   ownerGroupId: GroupId.optional(),
+  requesterGroupIds: RequesterGroupIds.optional(),
+  visibility: ResourceVisibility.optional(),
   parentResourceId: ResourceId.optional(),
   parentResourceTypeId: ResourceTypeId.optional(),
   auditNotifications: z.array(AuditNotification).max(1).optional(),
@@ -64,6 +82,8 @@ export const ResourceOnDB = z.object({
   resourceTypeId: ResourceTypeId,
   approverGroupId: GroupId.optional(),
   ownerGroupId: GroupId.optional(),
+  requesterGroupIds: RequesterGroupIds.optional(),
+  visibility: ResourceVisibility.optional(),
   auditNotifications: z.array(AuditNotification).max(1).optional(),
   pendingUpdateParams: PendingUpdateParams,
 });

--- a/packages/types/src/pluginInterface/database/resource.ts
+++ b/packages/types/src/pluginInterface/database/resource.ts
@@ -42,6 +42,20 @@ export type DeleteAuditNotificationInput = z.infer<typeof DeleteAuditNotificatio
 export type DeleteAuditNotificationOutput = ResultAsync<ResourceOnDB, DBError>;
 export type DeleteAuditNotification = (input: DeleteAuditNotificationInput) => DeleteAuditNotificationOutput;
 
+export const ListResourceByResourceTypeInput = z.object({
+  catalogId: CatalogId,
+  resourceTypeId: ResourceTypeId,
+  paginationToken: z.string().optional(),
+  limit: z.number().int().min(1).max(200).optional(),
+});
+export type ListResourceByResourceTypeInput = z.infer<typeof ListResourceByResourceTypeInput>;
+export type ListResourceByResourceTypeOutput = ResultAsync<{ items: Array<ResourceOnDB>; paginationToken?: string }, DBError>;
+/**
+ * List all ResourceOnDB rows of a resource type (i.e. resources that have any hub-side setting).
+ * Used to evaluate visibility for a whole list page without per-item reads.
+ */
+export type ListResourceByResourceType = (input: ListResourceByResourceTypeInput) => ListResourceByResourceTypeOutput;
+
 export type ResourceDBProvider = {
   getById(input: ResourceInput): ResourceDBGetByIdResult;
   set(resourceOnDB: ResourceOnDB): ResourceDBSetResult;
@@ -50,4 +64,5 @@ export type ResourceDBProvider = {
   createAuditNotification: CreateAuditNotification;
   updateAuditNotification: UpdateAuditNotification;
   deleteAuditNotification: DeleteAuditNotification;
+  listByResourceType: ListResourceByResourceType;
 };

--- a/plugins/dynamodb-db/src/resource.test.ts
+++ b/plugins/dynamodb-db/src/resource.test.ts
@@ -13,6 +13,7 @@ import {
   deleteAuditNotificationImpl,
   deleteImpl,
   getByIdImpl,
+  listByResourceTypeImpl,
   setImpl,
   updateAuditNotificationImpl,
   updatePendingUpdateParamsImpl,
@@ -752,6 +753,109 @@ describe("Testing resource", () => {
       }
 
       expect(result.value.pendingUpdateParams).toEqual(updatedParams);
+    });
+  });
+  describe("requesterGroupIds / visibility round-trip", () => {
+    const requesterGroupIds = ["1f10d463-a2fe-c407-2b95-05b561346c8b", "7c2b9e4d-1a3f-4c5e-9b8a-6d5c4b3a2f1e"];
+
+    it("should persist requesterGroupIds and visibility", async () => {
+      const resourceInput: ResourceOnDB = {
+        id,
+        catalogId,
+        resourceTypeId,
+        requesterGroupIds,
+        visibility: "restricted",
+      };
+      const setResult = await setImpl(logger)(resourceInput, tableName, config);
+      if (setResult.isErr()) {
+        throw setResult.error;
+      }
+      const getResult = await getByIdImpl(logger)({ id, catalogId, resourceTypeId }, tableName, config);
+      if (getResult.isErr()) {
+        throw getResult.error;
+      }
+      expect(getResult.value).toEqual(some(resourceInput));
+    });
+
+    it("should remove the attributes when set with undefined", async () => {
+      const resourceInput: ResourceOnDB = {
+        id,
+        catalogId,
+        resourceTypeId,
+        requesterGroupIds: undefined,
+        visibility: undefined,
+      };
+      const setResult = await setImpl(logger)(resourceInput, tableName, config);
+      if (setResult.isErr()) {
+        throw setResult.error;
+      }
+      const getResult = await getByIdImpl(logger)({ id, catalogId, resourceTypeId }, tableName, config);
+      if (getResult.isErr()) {
+        throw getResult.error;
+      }
+      expect(getResult.value.isSome()).toBe(true);
+      if (getResult.value.isNone()) throw new Error("expected some");
+      expect(getResult.value.value.requesterGroupIds).toBeUndefined();
+      expect(getResult.value.value.visibility).toBeUndefined();
+    });
+  });
+
+  describe("listByResourceTypeImpl", () => {
+    const listCatalogId = "test-list-catalog-resource";
+    const listResourceTypeId = "test-list-resource-type";
+    const otherResourceTypeId = "test-list-other-resource-type";
+    const ids = ["list-resource-1", "list-resource-2", "list-resource-3"];
+
+    beforeAll(async () => {
+      for (const listId of ids) {
+        await setImpl(logger)({ id: listId, catalogId: listCatalogId, resourceTypeId: listResourceTypeId, visibility: "restricted" }, tableName, config);
+      }
+      await setImpl(logger)({ id: "other-resource", catalogId: listCatalogId, resourceTypeId: otherResourceTypeId }, tableName, config);
+    });
+    afterAll(async () => {
+      for (const listId of ids) {
+        await deleteImpl(logger)({ id: listId, catalogId: listCatalogId, resourceTypeId: listResourceTypeId }, tableName, config);
+      }
+      await deleteImpl(logger)({ id: "other-resource", catalogId: listCatalogId, resourceTypeId: otherResourceTypeId }, tableName, config);
+    });
+
+    it("should list only rows of the given resource type", async () => {
+      const result = await listByResourceTypeImpl(logger)({ catalogId: listCatalogId, resourceTypeId: listResourceTypeId }, tableName, config);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value.items.map((item) => item.id).sort()).toEqual([...ids].sort());
+      expect(result.value.items.every((item) => item.resourceTypeId === listResourceTypeId && item.visibility === "restricted")).toBe(true);
+      expect(result.value.paginationToken).toBeUndefined();
+    });
+
+    it("should paginate with limit and paginationToken", async () => {
+      const first = await listByResourceTypeImpl(logger)({ catalogId: listCatalogId, resourceTypeId: listResourceTypeId, limit: 2 }, tableName, config);
+      if (first.isErr()) {
+        throw first.error;
+      }
+      expect(first.value.items.length).toBe(2);
+      expect(first.value.paginationToken).toBeDefined();
+
+      const second = await listByResourceTypeImpl(logger)(
+        { catalogId: listCatalogId, resourceTypeId: listResourceTypeId, limit: 2, paginationToken: first.value.paginationToken },
+        tableName,
+        config
+      );
+      if (second.isErr()) {
+        throw second.error;
+      }
+      const all = [...first.value.items, ...second.value.items].map((item) => item.id).sort();
+      expect(all).toEqual([...ids].sort());
+    });
+
+    it("should return an empty list for an unknown resource type", async () => {
+      const result = await listByResourceTypeImpl(logger)({ catalogId: listCatalogId, resourceTypeId: "no-such-type" }, tableName, config);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value.items).toEqual([]);
+      expect(result.value.paginationToken).toBeUndefined();
     });
   });
 });

--- a/plugins/dynamodb-db/src/resource.ts
+++ b/plugins/dynamodb-db/src/resource.ts
@@ -1,5 +1,5 @@
 import { DynamoDBClient, DynamoDBClientConfig } from "@aws-sdk/client-dynamodb";
-import { DeleteCommand, DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { DeleteCommand, DynamoDBDocumentClient, GetCommand, PutCommand, QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { Logger } from "@stamp-lib/stamp-logger";
 import { none, some } from "@stamp-lib/stamp-option";
 import { ResourceOnDB } from "@stamp-lib/stamp-types/models";
@@ -9,6 +9,8 @@ import {
   DBError,
   DeleteAuditNotificationInput,
   DeleteAuditNotificationOutput,
+  ListResourceByResourceTypeInput,
+  ListResourceByResourceTypeOutput,
   ResourceDBDeleteResult,
   ResourceDBGetByIdResult,
   ResourceDBProvider,
@@ -19,7 +21,9 @@ import {
   UpdatePendingUpdateParamsInput,
 } from "@stamp-lib/stamp-types/pluginInterface/database";
 import { errAsync, okAsync, ResultAsync } from "neverthrow";
+import { z } from "zod";
 import { parseDBInputAsync, parseDBItemAsync } from "./utils/neverthrow";
+import { deserializeObject, serializeObject } from "./utils/pagination";
 
 export function getByIdImpl(logger: Logger) {
   return (input: ResourceInput, TableName: string, config: DynamoDBClientConfig = {}): ResourceDBGetByIdResult => {
@@ -384,6 +388,47 @@ export function deleteAuditNotificationImpl(logger: Logger) {
   };
 }
 
+export function listByResourceTypeImpl(logger: Logger) {
+  return (input: ListResourceByResourceTypeInput, TableName: string, config: DynamoDBClientConfig = {}): ListResourceByResourceTypeOutput => {
+    const client = new DynamoDBClient(config);
+    const ddbDocClient = DynamoDBDocumentClient.from(client);
+
+    return parseDBInputAsync(input, ListResourceByResourceTypeInput).andThen((parsedInput) => {
+      const compositeKey = `${parsedInput.catalogId}#${parsedInput.resourceTypeId}`;
+      const exclusiveStartKey = parsedInput.paginationToken ? deserializeObject(parsedInput.paginationToken) : undefined;
+
+      const queryResult = ResultAsync.fromPromise(
+        ddbDocClient.send(
+          new QueryCommand({
+            TableName: TableName,
+            KeyConditionExpression: "#catalogIdResourceTypeId = :catalogIdResourceTypeId",
+            ExpressionAttributeNames: {
+              "#catalogIdResourceTypeId": "catalogId#resourceTypeId",
+            },
+            ExpressionAttributeValues: {
+              ":catalogIdResourceTypeId": compositeKey,
+            },
+            ExclusiveStartKey: exclusiveStartKey,
+            Limit: parsedInput.limit,
+          })
+        ),
+        (err) => {
+          logger.error(err);
+          return new DBError((err as Error).message ?? "Internal Server Error", "INTERNAL_SERVER_ERROR");
+        }
+      );
+
+      return queryResult.andThen((result) => {
+        const paginationToken = result.LastEvaluatedKey ? serializeObject(result.LastEvaluatedKey) : undefined;
+        if (result.Items === undefined || result.Items.length === 0) {
+          return okAsync({ items: [], paginationToken });
+        }
+        return parseDBItemAsync(logger)(result.Items, z.array(ResourceOnDB)).map((items) => ({ items, paginationToken }));
+      });
+    });
+  };
+}
+
 export const createResourceDBProvider =
   (logger: Logger) =>
   (TableName: string, config: DynamoDBClientConfig = {}): ResourceDBProvider => {
@@ -395,5 +440,6 @@ export const createResourceDBProvider =
       createAuditNotification: (input: CreateAuditNotificationInput) => createAuditNotificationImpl(logger)(input, TableName, config),
       updateAuditNotification: (input: UpdateAuditNotificationInput) => updateAuditNotificationImpl(logger)(input, TableName, config),
       deleteAuditNotification: (input: DeleteAuditNotificationInput) => deleteAuditNotificationImpl(logger)(input, TableName, config),
+      listByResourceType: (input: ListResourceByResourceTypeInput) => listByResourceTypeImpl(logger)(input, TableName, config),
     };
   };

--- a/plugins/ephemeral-db/src/resource.ts
+++ b/plugins/ephemeral-db/src/resource.ts
@@ -1,7 +1,12 @@
 import { Logger } from "@stamp-lib/stamp-logger";
 import { none, some } from "@stamp-lib/stamp-option";
 import { CatalogId, ResourceId, ResourceOnDB, ResourceTypeId } from "@stamp-lib/stamp-types/models";
-import { ResourceDBProvider, ResourceInput, UpdatePendingUpdateParamsInput } from "@stamp-lib/stamp-types/pluginInterface/database";
+import {
+  ListResourceByResourceTypeInput,
+  ResourceDBProvider,
+  ResourceInput,
+  UpdatePendingUpdateParamsInput,
+} from "@stamp-lib/stamp-types/pluginInterface/database";
 import { errAsync, okAsync } from "neverthrow";
 
 const resourceMap = new Map<CatalogId, Map<ResourceTypeId, Map<ResourceId, ResourceOnDB>>>();
@@ -46,6 +51,11 @@ export function createResourceDBProvider(logger: Logger): ResourceDBProvider {
       resourceMap.get(input.catalogId)?.get(input.resourceTypeId)?.set(input.id, structuredClone(updatedResource));
       return okAsync(structuredClone(updatedResource));
     },
+    listByResourceType: (input: ListResourceByResourceTypeInput) => {
+      logger.info("ResourceDB.listByResourceType", input.catalogId, input.resourceTypeId);
+      const resources = Array.from(resourceMap.get(input.catalogId)?.get(input.resourceTypeId)?.values() ?? []);
+      return okAsync({ items: structuredClone(resources) });
+    },
     delete: (input: ResourceInput) => {
       logger.info("ResourceDB.delete", input.id);
       resourceMap.delete(input.id);
@@ -63,6 +73,8 @@ export function createResourceDBProvider(logger: Logger): ResourceDBProvider {
         resourceTypeId: resource.resourceTypeId,
         approverGroupId: resource.approverGroupId,
         ownerGroupId: resource.ownerGroupId,
+        requesterGroupIds: resource.requesterGroupIds,
+        visibility: resource.visibility,
         auditNotifications: [
           {
             schedulerEventId: input.schedulerEventId,
@@ -86,6 +98,8 @@ export function createResourceDBProvider(logger: Logger): ResourceDBProvider {
         resourceTypeId: resource.resourceTypeId,
         approverGroupId: resource.approverGroupId,
         ownerGroupId: resource.ownerGroupId,
+        requesterGroupIds: resource.requesterGroupIds,
+        visibility: resource.visibility,
         auditNotifications: [
           {
             schedulerEventId: input.schedulerEventId,
@@ -109,6 +123,8 @@ export function createResourceDBProvider(logger: Logger): ResourceDBProvider {
         resourceTypeId: resource.resourceTypeId,
         approverGroupId: resource.approverGroupId,
         ownerGroupId: resource.ownerGroupId,
+        requesterGroupIds: resource.requesterGroupIds,
+        visibility: resource.visibility,
       };
       return okAsync(newResourceOnDB);
     },


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### 🎉 Reason for this change

Today every user can submit an Approval Request for any Resource, and every user can list / view every Resource. Catalog and Resource Owners have asked to (1) limit who may *request* a Resource to specific user groups and (2) hide sensitive Resources (and the requests made against them) from everyone who is not involved.

This is stack **1/4** of that feature (GitHub stack #104): it introduces the data model and the settings API only. Nothing reads the new fields yet, so behavior is unchanged until #103.

### 🔀 Description of changes

Two optional, independent settings on the hub-side resource record (`ResourceOnDB` / `ResourceInfo`):

| Field | Meaning |
| --- | --- |
| `requesterGroupIds: GroupId[]` (max 10) | Only members of one of these groups may submit approval requests that include the resource. `undefined` / `[]` = anyone (current behavior). |
| `visibility: "all" \| "restricted"` | `restricted` = only members of owner / approver / requester groups, the catalog owner and the parent resource owner can see the resource. `undefined` = `all`. |

- New mutations `resource.updateRequesterGroups` (validates that each group exists → `BAD_REQUEST`) and `resource.updateVisibility`; both authorized with the existing `createCheckCanEditResource` (Catalog Owner / Resource Owner / Parent Resource Owner). Both fields are also accepted on `resource.create`.
- Values are normalized before persisting: `[]` → `undefined`, `"all"` → `undefined`, so the DynamoDB attribute is removed rather than stored empty.
- `ApprovalRequestVisibility` + optional `SubmittedRequest.visibility` snapshot field (populated by the hub in #103; excluded from `SubmitWorkflowInput` so clients cannot set it).
- `ResourceDBProvider.listByResourceType`: DynamoDB `Query` on the `catalogId#resourceTypeId` hash key (paginated) and an ephemeral in-memory implementation. Lets list pages evaluate visibility with a constant number of reads instead of one `getById` per item (used in #103).
- ephemeral-db audit-notification operations now carry the new fields.

Design decisions: no `ResourceTypeConfig` opt-in flag (available for every resource type); settings are per resource and are not inherited by child resources.

### 🖨️ Description of how you validated changes

- New unit tests: `updateResourceRequesterGroups.test.ts`, `updateResourceVisibility.test.ts`, `normalizeResourceAccessSettings.test.ts`; `createResource.test.ts` extended (+3). `packages/hub`: 511 tests pass.
- `plugins/dynamodb-db/src/resource.test.ts`: round-trip of the new fields and `listByResourceTypeImpl` (type filter, pagination, empty result). Not run locally (needs live DynamoDB / `DYNAMO_TABLE_PREFIX`).
- `npm run lint` (root) clean; `lerna run build` succeeds for all packages.

### 🔗 Related links

- Stack: #102 (this) → #103 → #105 → #106
- Authorization model: `packages/hub/README.md` (updated in #105)
