### PR TITLE
feat(hub): enforce resource requester groups and visibility (stack 2/4)

### DIFF
--- a/packages/hub/src/events/approval-request/authz/submit.test.ts
+++ b/packages/hub/src/events/approval-request/authz/submit.test.ts
@@ -1,0 +1,90 @@
+import { none, some } from "@stamp-lib/stamp-option";
+import { DBError } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { errAsync, okAsync } from "neverthrow";
+import { describe, expect, it, vi } from "vitest";
+import { checkCanSubmitRequestForResources, createFindResourceNotRequestableBy } from "./submit";
+
+const userId = "47f29c51-204c-09f6-2069-f3df073568c7";
+const groupA = "1f10d463-a2fe-c407-2b95-05b561346c8b";
+const groupB = "7c2b9e4d-1a3f-4c5e-9b8a-6d5c4b3a2f1e";
+const ownerGroupId = "96fc6a4c-b5d3-8c2b-0307-165168a023cd";
+const catalogId = "test-catalog-id";
+
+const rows: Record<string, { requesterGroupIds?: Array<string>; ownerGroupId?: string; visibility?: "all" | "restricted" }> = {
+  open: {},
+  emptyList: { requesterGroupIds: [] },
+  restrictedA: { requesterGroupIds: [groupA], visibility: "restricted" },
+  restrictedAB: { requesterGroupIds: [groupA, groupB] },
+  ownedNotRequestable: { requesterGroupIds: [groupA], ownerGroupId },
+};
+const getResourceById = vi.fn(({ id }: { id: string }) => okAsync(id in rows ? some({ id, catalogId, resourceTypeId: "t", ...rows[id] }) : none));
+const memberOf = (groups: Array<string>) => vi.fn(({ groupId }: { groupId: string }) => okAsync(groups.includes(groupId) ? some({}) : none));
+
+const input = (ids: Array<string>) => ({
+  catalogId,
+  approvalFlowId: "flow",
+  requestUserId: userId,
+  inputResources: ids.map((resourceId) => ({ resourceTypeId: "t", resourceId })),
+});
+
+describe("checkCanSubmitRequestForResources", () => {
+  it("passes when inputResources is empty without reading the DB", async () => {
+    const getById = vi.fn();
+    const result = await checkCanSubmitRequestForResources(getById, memberOf([]))(input([]));
+    expect(result.isOk()).toBe(true);
+    expect(getById).not.toHaveBeenCalled();
+  });
+
+  it("passes for resources without a DB row or without requesterGroupIds", async () => {
+    const result = await checkCanSubmitRequestForResources(getResourceById, memberOf([]))(input(["no-row", "open", "emptyList"]));
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("passes when the user is a member of one of several requester groups (visibility is irrelevant)", async () => {
+    const result = await checkCanSubmitRequestForResources(getResourceById, memberOf([groupB]))(input(["restrictedAB"]));
+    expect(result.isOk()).toBe(true);
+    const restricted = await checkCanSubmitRequestForResources(getResourceById, memberOf([groupA]))(input(["restrictedA"]));
+    expect(restricted.isOk()).toBe(true);
+  });
+
+  it("returns the original input on success", async () => {
+    const extra = { ...input(["open"]), somethingElse: 1 };
+    const result = await checkCanSubmitRequestForResources(getResourceById, memberOf([]))(extra);
+    expect(result._unsafeUnwrap()).toBe(extra);
+  });
+
+  it("returns FORBIDDEN naming the first non-requestable resource", async () => {
+    const result = await checkCanSubmitRequestForResources(getResourceById, memberOf([groupB]))(input(["open", "restrictedA", "restrictedAB"]));
+    const error = result._unsafeUnwrapErr();
+    expect(error.code).toBe("FORBIDDEN");
+    expect(error.systemMessage).toContain("t/restrictedA");
+    expect(error.userMessage).toBe("You are not allowed to submit a request for this resource");
+  });
+
+  it("gives resource owners no bypass", async () => {
+    const result = await checkCanSubmitRequestForResources(getResourceById, memberOf([ownerGroupId]))(input(["ownedNotRequestable"]));
+    expect(result._unsafeUnwrapErr().code).toBe("FORBIDDEN");
+  });
+
+  it("converts DB errors", async () => {
+    const failing = vi.fn().mockReturnValue(errAsync(new DBError("DB error")));
+    const result = await checkCanSubmitRequestForResources(failing, memberOf([]))(input(["open"]));
+    expect(result._unsafeUnwrapErr().code).toBe("INTERNAL_SERVER_ERROR");
+  });
+
+  it("rejects malformed input", async () => {
+    const result = await checkCanSubmitRequestForResources(getResourceById, memberOf([]))({ ...input(["open"]), requestUserId: "not-a-uuid" });
+    expect(result._unsafeUnwrapErr().code).toBe("BAD_REQUEST");
+  });
+});
+
+describe("createFindResourceNotRequestableBy", () => {
+  it("returns none when every resource is requestable and some when one is not", async () => {
+    const find = createFindResourceNotRequestableBy(getResourceById, memberOf([groupA]));
+    const refs = ["open", "restrictedA"].map((resourceId) => ({ catalogId, resourceTypeId: "t", resourceId }));
+    expect((await find(userId, refs))._unsafeUnwrap().isNone()).toBe(true);
+    const notMember = createFindResourceNotRequestableBy(getResourceById, memberOf([]));
+    const found = (await notMember(userId, refs))._unsafeUnwrap();
+    expect(found.isSome() && found.value.resourceId).toBe("restrictedA");
+  });
+});

--- a/packages/hub/src/events/approval-request/authz/submit.ts
+++ b/packages/hub/src/events/approval-request/authz/submit.ts
@@ -1,0 +1,68 @@
+import { Option, none, some } from "@stamp-lib/stamp-option";
+import { ResourceDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { GroupMemberShipProvider, UserId } from "@stamp-lib/stamp-types/pluginInterface/identity";
+import { ResultAsync, errAsync, okAsync } from "neverthrow";
+import { StampHubError, convertStampHubError } from "../../../error";
+import { SubmitApprovalRequestInput } from "../../../inputAuthzModel";
+import { parseZodObjectAsync } from "../../../utils/neverthrow";
+import { createIsUserInGroup } from "../../group/membership";
+import { createIsRequesterOfResource } from "../../resource/requester/isRequesterOfResource";
+import { ResourceRef, inputResourcesOfApprovalRequest } from "../resources";
+
+export type FindResourceNotRequestableBy = (userId: UserId, resources: Array<ResourceRef>) => ResultAsync<Option<ResourceRef>, StampHubError>;
+
+/**
+ * Returns the first resource (in order) whose `requesterGroupIds` does not include the user, or none.
+ */
+export function createFindResourceNotRequestableBy(
+  getResourceById: ResourceDBProvider["getById"],
+  getGroupMemberShip: GroupMemberShipProvider["get"]
+): FindResourceNotRequestableBy {
+  const isRequesterOfResource = createIsRequesterOfResource(createIsUserInGroup(getGroupMemberShip));
+  return (userId, resources) => {
+    if (resources.length === 0) {
+      return okAsync(none);
+    }
+    return ResultAsync.combine(
+      resources.map((ref) =>
+        getResourceById({ id: ref.resourceId, catalogId: ref.catalogId, resourceTypeId: ref.resourceTypeId })
+          .mapErr(convertStampHubError)
+          .andThen((resourceOnDB) => isRequesterOfResource({ requestUserId: userId, resourceOnDB }))
+          .map((isRequester) => ({ ref, isRequester }))
+      )
+    ).map((results) => {
+      const notRequestable = results.find((result) => !result.isRequester);
+      return notRequestable === undefined ? none : some(notRequestable.ref);
+    });
+  };
+}
+
+export type CheckCanSubmitRequestForResources = <T extends SubmitApprovalRequestInput>(input: T) => ResultAsync<T, StampHubError>;
+
+/**
+ * Submit authorization: the requester must be a member of `requesterGroupIds` of every input resource that has it set.
+ * Owners / approvers get no bypass. Visibility is a separate concern and is not checked here.
+ */
+export function checkCanSubmitRequestForResources(
+  getResourceById: ResourceDBProvider["getById"],
+  getGroupMemberShip: GroupMemberShipProvider["get"]
+): CheckCanSubmitRequestForResources {
+  const findResourceNotRequestableBy = createFindResourceNotRequestableBy(getResourceById, getGroupMemberShip);
+  return (input) =>
+    parseZodObjectAsync(input, SubmitApprovalRequestInput)
+      .andThen((parsedInput) => findResourceNotRequestableBy(parsedInput.requestUserId, inputResourcesOfApprovalRequest(parsedInput)))
+      .andThen((notRequestable) => {
+        if (notRequestable.isNone()) {
+          return okAsync(input);
+        }
+        const ref = notRequestable.value;
+        return errAsync(
+          new StampHubError(
+            `User ${input.requestUserId} is not in requesterGroupIds of resource ${ref.resourceTypeId}/${ref.resourceId}`,
+            "You are not allowed to submit a request for this resource",
+            "FORBIDDEN"
+          )
+        );
+      })
+      .mapErr(convertStampHubError);
+}

--- a/packages/hub/src/events/approval-request/resources.test.ts
+++ b/packages/hub/src/events/approval-request/resources.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { inputResourcesOfApprovalRequest, resourcesOfApprovalRequest } from "./resources";
+
+describe("resourcesOfApprovalRequest", () => {
+  it("maps inputResources of a normal request", () => {
+    const request = {
+      catalogId: "cat",
+      approvalFlowId: "flow",
+      inputResources: [{ resourceTypeId: "t1", resourceId: "r1" }],
+      inputParams: [{ id: "x", value: "y" }],
+    };
+    expect(resourcesOfApprovalRequest(request)).toEqual([{ catalogId: "cat", resourceTypeId: "t1", resourceId: "r1" }]);
+    expect(inputResourcesOfApprovalRequest(request)).toEqual([{ catalogId: "cat", resourceTypeId: "t1", resourceId: "r1" }]);
+  });
+
+  it("recovers the target resource of a stamp-system/resource-update request from inputParams", () => {
+    const request = {
+      catalogId: "stamp-system",
+      approvalFlowId: "resource-update",
+      inputResources: [],
+      inputParams: [
+        { id: "catalogId", value: "cat" },
+        { id: "resourceTypeId", value: "t1" },
+        { id: "resourceId", value: "r1" },
+        { id: "updateParams", value: "{}" },
+      ],
+    };
+    expect(resourcesOfApprovalRequest(request)).toEqual([{ catalogId: "cat", resourceTypeId: "t1", resourceId: "r1" }]);
+    // requester authorization only looks at inputResources
+    expect(inputResourcesOfApprovalRequest(request)).toEqual([]);
+  });
+
+  it("ignores incomplete resource-update params", () => {
+    const request = {
+      catalogId: "stamp-system",
+      approvalFlowId: "resource-update",
+      inputResources: [],
+      inputParams: [{ id: "catalogId", value: "cat" }],
+    };
+    expect(resourcesOfApprovalRequest(request)).toEqual([]);
+  });
+});

--- a/packages/hub/src/events/approval-request/resources.ts
+++ b/packages/hub/src/events/approval-request/resources.ts
@@ -1,0 +1,45 @@
+import { ApprovalRequestInputParam, ApprovalRequestInputResource, CatalogId, ResourceId, ResourceTypeId } from "@stamp-lib/stamp-types/models";
+
+export type ResourceRef = { catalogId: CatalogId; resourceTypeId: ResourceTypeId; resourceId: ResourceId };
+
+export type ApprovalRequestResourcesSource = {
+  catalogId: CatalogId;
+  approvalFlowId: string;
+  inputResources: Array<ApprovalRequestInputResource>;
+  inputParams: Array<ApprovalRequestInputParam>;
+};
+
+export const SYSTEM_CATALOG_ID = "stamp-system";
+export const RESOURCE_UPDATE_APPROVAL_FLOW_ID = "resource-update";
+
+/**
+ * Resources a request refers to for requester authorization: the request's inputResources.
+ */
+export function inputResourcesOfApprovalRequest(request: Pick<ApprovalRequestResourcesSource, "catalogId" | "inputResources">): Array<ResourceRef> {
+  return request.inputResources.map((resource) => ({
+    catalogId: request.catalogId,
+    resourceTypeId: resource.resourceTypeId,
+    resourceId: resource.resourceId,
+  }));
+}
+
+/**
+ * Resources a request refers to for visibility purposes.
+ * In addition to inputResources, the built-in "stamp-system/resource-update" flow carries its target resource in inputParams.
+ */
+export function resourcesOfApprovalRequest(request: ApprovalRequestResourcesSource): Array<ResourceRef> {
+  const refs = inputResourcesOfApprovalRequest(request);
+  if (request.catalogId === SYSTEM_CATALOG_ID && request.approvalFlowId === RESOURCE_UPDATE_APPROVAL_FLOW_ID) {
+    const param = (id: string) => {
+      const value = request.inputParams.find((p) => p.id === id)?.value;
+      return typeof value === "string" && value.length > 0 ? value : undefined;
+    };
+    const catalogId = param("catalogId");
+    const resourceTypeId = param("resourceTypeId");
+    const resourceId = param("resourceId");
+    if (catalogId && resourceTypeId && resourceId) {
+      refs.push({ catalogId, resourceTypeId, resourceId });
+    }
+  }
+  return refs;
+}

--- a/packages/hub/src/events/approval-request/visibility/buildRequestVisibility.test.ts
+++ b/packages/hub/src/events/approval-request/visibility/buildRequestVisibility.test.ts
@@ -1,0 +1,99 @@
+import { none, some } from "@stamp-lib/stamp-option";
+import { HandlerError, ResourceHandlers } from "@stamp-lib/stamp-types/catalogInterface/handler";
+import { CatalogConfig, ResourceOnDB, ResourceTypeConfig } from "@stamp-lib/stamp-types/models";
+import { err, ok, okAsync } from "neverthrow";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createBuildRequestVisibility } from "./buildRequestVisibility";
+
+const catalogId = "test-catalog-id";
+const childTypeId = "child-type";
+const parentTypeId = "parent-type";
+const ownerGroupId = "96fc6a4c-b5d3-8c2b-0307-165168a023cd";
+const approverGroupId = "18578bed-c45d-4f67-b9f7-10daf4c85f3f";
+const requesterGroupId = "1f10d463-a2fe-c407-2b95-05b561346c8b";
+const parentOwnerGroupId = "5e8f1c2a-3b4d-4e5f-8a9b-0c1d2e3f4a5b";
+
+const getResourceHandler = vi.fn();
+const handlers: ResourceHandlers = {
+  createResource: async () => err(new HandlerError("not implemented", "INTERNAL_SERVER_ERROR")),
+  deleteResource: async () => err(new HandlerError("not implemented", "INTERNAL_SERVER_ERROR")),
+  getResource: getResourceHandler,
+  listResources: async () => err(new HandlerError("not implemented", "INTERNAL_SERVER_ERROR")),
+  updateResource: async () => err(new HandlerError("not implemented", "INTERNAL_SERVER_ERROR")),
+  listResourceAuditItem: async () => err(new HandlerError("not implemented", "INTERNAL_SERVER_ERROR")),
+};
+const baseType = { name: "t", description: "t", createParams: [], infoParams: [], handlers, isCreatable: false, isUpdatable: false, isDeletable: false, ownerManagement: true, approverManagement: true };
+const childType: ResourceTypeConfig = { ...baseType, id: childTypeId, parentResourceTypeId: parentTypeId };
+const parentType: ResourceTypeConfig = { ...baseType, id: parentTypeId };
+const catalogConfig: CatalogConfig = { id: catalogId, name: "c", description: "c", approvalFlows: [], resourceTypes: [childType, parentType] };
+const getCatalogConfigProvider = vi.fn().mockReturnValue(okAsync(some(catalogConfig)));
+
+const rows: Record<string, ResourceOnDB> = {
+  open: { id: "open", catalogId, resourceTypeId: parentTypeId, ownerGroupId },
+  restrictedParent: { id: "restrictedParent", catalogId, resourceTypeId: parentTypeId, ownerGroupId, approverGroupId, visibility: "restricted" },
+  restrictedChild: { id: "restrictedChild", catalogId, resourceTypeId: childTypeId, requesterGroupIds: [requesterGroupId, ownerGroupId], visibility: "restricted" },
+  parentOfChild: { id: "parentOfChild", catalogId, resourceTypeId: parentTypeId, ownerGroupId: parentOwnerGroupId },
+};
+const getResourceById = vi.fn(({ id }: { id: string }) => okAsync(id in rows ? some(rows[id]) : none));
+
+const request = (inputResources: Array<{ resourceTypeId: string; resourceId: string }>) => ({
+  catalogId,
+  approvalFlowId: "flow",
+  inputResources,
+  inputParams: [],
+});
+
+describe("createBuildRequestVisibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getResourceHandler.mockResolvedValue(ok(some({ resourceId: "restrictedChild", name: "n", params: {}, parentResourceId: "parentOfChild" })));
+  });
+  const build = createBuildRequestVisibility({ getResourceById, getCatalogConfigProvider });
+
+  it("returns undefined when there are no resources", async () => {
+    expect((await build(request([])))._unsafeUnwrap()).toBeUndefined();
+    expect(getResourceById).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined when no resource is restricted and does not call the handler", async () => {
+    const result = await build(request([{ resourceTypeId: parentTypeId, resourceId: "open" }, { resourceTypeId: parentTypeId, resourceId: "no-row" }]));
+    expect(result._unsafeUnwrap()).toBeUndefined();
+    expect(getResourceHandler).not.toHaveBeenCalled();
+  });
+
+  it("collects owner / approver groups of a restricted resource without a parent type", async () => {
+    const result = await build(request([{ resourceTypeId: parentTypeId, resourceId: "restrictedParent" }]));
+    expect(result._unsafeUnwrap()).toEqual({ type: "restricted", viewerGroupIds: [ownerGroupId, approverGroupId] });
+    expect(getResourceHandler).not.toHaveBeenCalled();
+  });
+
+  it("adds requester groups and the parent owner group for a restricted child, deduped", async () => {
+    const result = await build(request([{ resourceTypeId: childTypeId, resourceId: "restrictedChild" }, { resourceTypeId: parentTypeId, resourceId: "restrictedParent" }]));
+    const visibility = result._unsafeUnwrap();
+    expect(visibility?.type).toBe("restricted");
+    expect(new Set(visibility?.viewerGroupIds)).toEqual(new Set([requesterGroupId, ownerGroupId, approverGroupId, parentOwnerGroupId]));
+    expect(visibility?.viewerGroupIds.length).toBe(4);
+    expect(getResourceHandler).toHaveBeenCalledTimes(1);
+    expect(getResourceHandler).toHaveBeenCalledWith({ resourceTypeId: childTypeId, resourceId: "restrictedChild" });
+  });
+
+  it("uses inputParams for stamp-system/resource-update requests", async () => {
+    const result = await build({
+      catalogId: "stamp-system",
+      approvalFlowId: "resource-update",
+      inputResources: [],
+      inputParams: [
+        { id: "catalogId", value: catalogId },
+        { id: "resourceTypeId", value: parentTypeId },
+        { id: "resourceId", value: "restrictedParent" },
+      ],
+    });
+    expect(result._unsafeUnwrap()).toEqual({ type: "restricted", viewerGroupIds: [ownerGroupId, approverGroupId] });
+  });
+
+  it("ignores a missing parent", async () => {
+    getResourceHandler.mockResolvedValue(ok(some({ resourceId: "restrictedChild", name: "n", params: {} })));
+    const result = await build(request([{ resourceTypeId: childTypeId, resourceId: "restrictedChild" }]));
+    expect(result._unsafeUnwrap()).toEqual({ type: "restricted", viewerGroupIds: [requesterGroupId, ownerGroupId] });
+  });
+});

--- a/packages/hub/src/events/approval-request/visibility/buildRequestVisibility.ts
+++ b/packages/hub/src/events/approval-request/visibility/buildRequestVisibility.ts
@@ -1,0 +1,82 @@
+import { CatalogConfigProvider } from "@stamp-lib/stamp-types/configInterface";
+import { ApprovalRequestVisibility, ResourceOnDB } from "@stamp-lib/stamp-types/models";
+import { ResourceDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { GroupId } from "@stamp-lib/stamp-types/pluginInterface/identity";
+import { ResultAsync, okAsync } from "neverthrow";
+import { StampHubError, convertStampHubError } from "../../../error";
+import { convertPromiseResultToResultAsync } from "../../../utils/neverthrow";
+import { createGetCatalogConfig } from "../../catalog/catalogConfig";
+import { getResourceTypeConfig } from "../../resource-type/resourceTypeConfig";
+import { ApprovalRequestResourcesSource, ResourceRef, resourcesOfApprovalRequest } from "../resources";
+
+export type BuildRequestVisibility = (request: ApprovalRequestResourcesSource) => ResultAsync<ApprovalRequestVisibility | undefined, StampHubError>;
+
+/**
+ * Compute the visibility snapshot stored on an approval request at submit time.
+ * If any referenced resource is restricted, the snapshot lists every group that may view it:
+ * owner / approver / requester groups of those resources plus their parent resource's owner group.
+ * Returns undefined when no referenced resource is restricted.
+ */
+export function createBuildRequestVisibility(deps: {
+  getResourceById: ResourceDBProvider["getById"];
+  getCatalogConfigProvider: CatalogConfigProvider["get"];
+}): BuildRequestVisibility {
+  const getCatalogConfig = createGetCatalogConfig(deps.getCatalogConfigProvider);
+
+  const resolveParentOwnerGroupId = (ref: ResourceRef): ResultAsync<GroupId | undefined, StampHubError> =>
+    getCatalogConfig({ catalogId: ref.catalogId, resourceTypeId: ref.resourceTypeId })
+      .andThen(getResourceTypeConfig)
+      .andThen((extendInput) => {
+        const parentResourceTypeId = extendInput.resourceTypeConfig.parentResourceTypeId;
+        if (parentResourceTypeId === undefined) {
+          return okAsync(undefined);
+        }
+        return convertPromiseResultToResultAsync()(
+          extendInput.resourceTypeConfig.handlers.getResource({ resourceTypeId: ref.resourceTypeId, resourceId: ref.resourceId })
+        ).andThen((resource) => {
+          if (resource.isNone() || resource.value.parentResourceId === undefined) {
+            return okAsync(undefined);
+          }
+          return deps
+            .getResourceById({ id: resource.value.parentResourceId, catalogId: ref.catalogId, resourceTypeId: parentResourceTypeId })
+            .mapErr(convertStampHubError)
+            .map((parent) => (parent.isSome() ? parent.value.ownerGroupId : undefined));
+        });
+      })
+      .mapErr(convertStampHubError);
+
+  return (request) => {
+    const refs = resourcesOfApprovalRequest(request);
+    if (refs.length === 0) {
+      return okAsync(undefined);
+    }
+    return ResultAsync.combine(
+      refs.map((ref) =>
+        deps
+          .getResourceById({ id: ref.resourceId, catalogId: ref.catalogId, resourceTypeId: ref.resourceTypeId })
+          .mapErr(convertStampHubError)
+          .map((resourceOnDB) => ({ ref, resourceOnDB }))
+      )
+    ).andThen((rows) => {
+      const restricted = rows.flatMap(({ ref, resourceOnDB }) =>
+        resourceOnDB.isSome() && resourceOnDB.value.visibility === "restricted" ? [{ ref, resource: resourceOnDB.value as ResourceOnDB }] : []
+      );
+      if (restricted.length === 0) {
+        return okAsync(undefined);
+      }
+      const viewerGroupIds = new Set<GroupId>();
+      restricted.forEach(({ resource }) => {
+        if (resource.ownerGroupId) viewerGroupIds.add(resource.ownerGroupId);
+        if (resource.approverGroupId) viewerGroupIds.add(resource.approverGroupId);
+        resource.requesterGroupIds?.forEach((groupId) => viewerGroupIds.add(groupId));
+      });
+      return ResultAsync.combine(restricted.map(({ ref }) => resolveParentOwnerGroupId(ref))).map((parentOwnerGroupIds) => {
+        parentOwnerGroupIds.forEach((groupId) => {
+          if (groupId) viewerGroupIds.add(groupId);
+        });
+        const visibility: ApprovalRequestVisibility = { type: "restricted", viewerGroupIds: Array.from(viewerGroupIds) };
+        return visibility;
+      });
+    });
+  };
+}

--- a/packages/hub/src/events/group/membership.test.ts
+++ b/packages/hub/src/events/group/membership.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createIsUserInGroup, createIsGroupOwner } from "./membership";
+import { createIsUserInGroup, createIsGroupOwner, createIsUserInGroupFromSet, createListAllGroupIdsByUser } from "./membership";
 import { some, none } from "@stamp-lib/stamp-option";
 import { IdentityPluginError } from "@stamp-lib/stamp-types/pluginInterface/identity";
 import { okAsync, errAsync } from "neverthrow";
@@ -132,5 +132,60 @@ describe("Testing membership", () => {
       const result = await isGroupOwnerImpl(input);
       expect(result.isErr()).toBe(true);
     });
+  });
+});
+
+describe("createIsUserInGroupFromSet", () => {
+  const userId = "47f29c51-204c-09f6-2069-f3df073568c7";
+  const groupId = "1f10d463-a2fe-c407-2b95-05b561346c8b";
+  const otherGroupId = "7c2b9e4d-1a3f-4c5e-9b8a-6d5c4b3a2f1e";
+
+  it("returns true for a group in the set and false otherwise", async () => {
+    const isUserInGroup = createIsUserInGroupFromSet(new Set([groupId]));
+    expect((await isUserInGroup({ userId, groupId }))._unsafeUnwrap()).toBe(true);
+    expect((await isUserInGroup({ userId, groupId: otherGroupId }))._unsafeUnwrap()).toBe(false);
+  });
+
+  it("validates input", async () => {
+    const isUserInGroup = createIsUserInGroupFromSet(new Set([groupId]));
+    const result = await isUserInGroup({ userId: "invalid", groupId });
+    expect(result.isErr()).toBe(true);
+  });
+});
+
+describe("createListAllGroupIdsByUser", () => {
+  const userId = "47f29c51-204c-09f6-2069-f3df073568c7";
+  const g1 = "1f10d463-a2fe-c407-2b95-05b561346c8b";
+  const g2 = "7c2b9e4d-1a3f-4c5e-9b8a-6d5c4b3a2f1e";
+  const membership = (groupId: string) => ({ groupId, userId, role: "member" as const, createdAt: "2024-01-01T00:00:00.000Z", updatedAt: "2024-01-01T00:00:00.000Z" });
+
+  it("collects a single page", async () => {
+    const listByUser = vi.fn().mockReturnValue(okAsync({ items: [membership(g1), membership(g2)] }));
+    const result = await createListAllGroupIdsByUser(listByUser)(userId);
+    expect(result._unsafeUnwrap()).toEqual(new Set([g1, g2]));
+    expect(listByUser).toHaveBeenCalledWith({ userId, limit: 100, paginationToken: undefined });
+  });
+
+  it("follows nextPaginationToken", async () => {
+    const listByUser = vi
+      .fn()
+      .mockReturnValueOnce(okAsync({ items: [membership(g1)], nextPaginationToken: "next" }))
+      .mockReturnValueOnce(okAsync({ items: [membership(g2)] }));
+    const result = await createListAllGroupIdsByUser(listByUser)(userId);
+    expect(result._unsafeUnwrap()).toEqual(new Set([g1, g2]));
+    expect(listByUser).toHaveBeenCalledTimes(2);
+    expect(listByUser.mock.calls[1][0].paginationToken).toBe("next");
+  });
+
+  it("propagates identity errors", async () => {
+    const listByUser = vi.fn().mockReturnValue(errAsync(new IdentityPluginError("This is Identity Plugin Error", "INTERNAL_SERVER_ERROR")));
+    const result = await createListAllGroupIdsByUser(listByUser)(userId);
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("stops with an error if the token never clears", async () => {
+    const listByUser = vi.fn().mockReturnValue(okAsync({ items: [], nextPaginationToken: "again" }));
+    const result = await createListAllGroupIdsByUser(listByUser)(userId);
+    expect(result._unsafeUnwrapErr().code).toBe("INTERNAL_SERVER_ERROR");
   });
 });

--- a/packages/hub/src/events/group/membership.ts
+++ b/packages/hub/src/events/group/membership.ts
@@ -2,7 +2,7 @@ import { GroupId, UserId, GroupMemberShipProvider } from "@stamp-lib/stamp-types
 import { convertStampHubError, StampHubError } from "../../error";
 import { parseZodObjectAsync } from "../../utils/neverthrow";
 import { z } from "zod";
-import { ResultAsync, okAsync } from "neverthrow";
+import { ResultAsync, errAsync, okAsync } from "neverthrow";
 
 export const IsUserInGroupInput = z.object({
   groupId: GroupId,
@@ -50,4 +50,40 @@ function isGroupOwnerImpl(input: IsGroupOwnerInput, getGroupMemberShip: GroupMem
 
 export function createIsGroupOwner(getGroupMemberShip: GroupMemberShipProvider["get"]): IsGroupOwner {
   return (input) => isGroupOwnerImpl(input, getGroupMemberShip);
+}
+
+/**
+ * IsUserInGroup backed by an in-memory set of the user's group ids.
+ * Use with `createListAllGroupIdsByUser` to evaluate many membership checks with a single identity lookup.
+ */
+export function createIsUserInGroupFromSet(groupIds: ReadonlySet<GroupId>): IsUserInGroup {
+  return (input) =>
+    parseZodObjectAsync(input, IsUserInGroupInput)
+      .andThen((parsedInput) => okAsync(groupIds.has(parsedInput.groupId)))
+      .mapErr(convertStampHubError);
+}
+
+export type ListAllGroupIdsByUser = (userId: UserId) => ResultAsync<Set<GroupId>, StampHubError>;
+
+const MAX_GROUP_MEMBERSHIP_PAGES = 50;
+
+/**
+ * Collect every group id the user belongs to by following listByUser pagination to the end.
+ */
+export function createListAllGroupIdsByUser(listByUser: GroupMemberShipProvider["listByUser"]): ListAllGroupIdsByUser {
+  const collect = (userId: UserId, paginationToken: string | undefined, acc: Set<GroupId>, page: number): ResultAsync<Set<GroupId>, StampHubError> => {
+    if (page >= MAX_GROUP_MEMBERSHIP_PAGES) {
+      return errAsync(new StampHubError(`Too many group membership pages for user ${userId}`, "Unexpected error occurred", "INTERNAL_SERVER_ERROR"));
+    }
+    return listByUser({ userId, limit: 100, paginationToken })
+      .mapErr(convertStampHubError)
+      .andThen((result) => {
+        result.items.forEach((membership) => acc.add(membership.groupId));
+        if (result.nextPaginationToken) {
+          return collect(userId, result.nextPaginationToken, acc, page + 1);
+        }
+        return okAsync(acc);
+      });
+  };
+  return (userId) => collect(userId, undefined, new Set<GroupId>(), 0);
 }

--- a/packages/hub/src/events/resource/info/listAllResourceOnDBByType.test.ts
+++ b/packages/hub/src/events/resource/info/listAllResourceOnDBByType.test.ts
@@ -1,0 +1,46 @@
+import { DBError } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { errAsync, okAsync } from "neverthrow";
+import { describe, expect, it, vi } from "vitest";
+import { createListAllResourceOnDBByType } from "./listAllResourceOnDBByType";
+
+const catalogId = "test-catalog-id";
+const resourceTypeId = "test-resource-type-id";
+const row = (id: string) => ({ id, catalogId, resourceTypeId, visibility: "restricted" as const });
+
+describe("createListAllResourceOnDBByType", () => {
+  it("collects a single page into a Map keyed by id", async () => {
+    const listByResourceType = vi.fn().mockReturnValue(okAsync({ items: [row("a"), row("b")] }));
+    const result = await createListAllResourceOnDBByType(listByResourceType)({ catalogId, resourceTypeId });
+    const map = result._unsafeUnwrap();
+    expect(Array.from(map.keys())).toEqual(["a", "b"]);
+    expect(map.get("a")?.visibility).toBe("restricted");
+    expect(listByResourceType).toHaveBeenCalledTimes(1);
+    expect(listByResourceType).toHaveBeenCalledWith({ catalogId, resourceTypeId, limit: 200, paginationToken: undefined });
+  });
+
+  it("follows paginationToken until exhausted", async () => {
+    const listByResourceType = vi
+      .fn()
+      .mockReturnValueOnce(okAsync({ items: [row("a")], paginationToken: "t1" }))
+      .mockReturnValueOnce(okAsync({ items: [row("b")], paginationToken: "t2" }))
+      .mockReturnValueOnce(okAsync({ items: [row("c")] }));
+    const result = await createListAllResourceOnDBByType(listByResourceType)({ catalogId, resourceTypeId });
+    expect(Array.from(result._unsafeUnwrap().keys())).toEqual(["a", "b", "c"]);
+    expect(listByResourceType).toHaveBeenCalledTimes(3);
+    expect(listByResourceType.mock.calls[1][0].paginationToken).toBe("t1");
+    expect(listByResourceType.mock.calls[2][0].paginationToken).toBe("t2");
+  });
+
+  it("propagates DB errors", async () => {
+    const listByResourceType = vi.fn().mockReturnValue(errAsync(new DBError("DB error")));
+    const result = await createListAllResourceOnDBByType(listByResourceType)({ catalogId, resourceTypeId });
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("fails instead of looping forever when the token never clears", async () => {
+    const listByResourceType = vi.fn().mockReturnValue(okAsync({ items: [], paginationToken: "again" }));
+    const result = await createListAllResourceOnDBByType(listByResourceType)({ catalogId, resourceTypeId });
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr().code).toBe("INTERNAL_SERVER_ERROR");
+  });
+});

--- a/packages/hub/src/events/resource/info/listAllResourceOnDBByType.ts
+++ b/packages/hub/src/events/resource/info/listAllResourceOnDBByType.ts
@@ -1,0 +1,37 @@
+import { CatalogId, ResourceId, ResourceOnDB, ResourceTypeId } from "@stamp-lib/stamp-types/models";
+import { ResourceDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { ResultAsync, errAsync, okAsync } from "neverthrow";
+import { StampHubError, convertStampHubError } from "../../../error";
+
+export type ListAllResourceOnDBByType = (input: { catalogId: CatalogId; resourceTypeId: ResourceTypeId }) => ResultAsync<Map<ResourceId, ResourceOnDB>, StampHubError>;
+
+const MAX_RESOURCE_PAGES = 100;
+
+/**
+ * Load every ResourceOnDB row of a resource type into a Map keyed by resource id,
+ * following pagination to the end. Rows exist only for resources with hub-side settings.
+ */
+export function createListAllResourceOnDBByType(listByResourceType: ResourceDBProvider["listByResourceType"]): ListAllResourceOnDBByType {
+  const collect = (
+    input: { catalogId: CatalogId; resourceTypeId: ResourceTypeId },
+    paginationToken: string | undefined,
+    acc: Map<ResourceId, ResourceOnDB>,
+    page: number
+  ): ResultAsync<Map<ResourceId, ResourceOnDB>, StampHubError> => {
+    if (page >= MAX_RESOURCE_PAGES) {
+      return errAsync(
+        new StampHubError(`Too many resource pages for ${input.catalogId}/${input.resourceTypeId}`, "Unexpected error occurred", "INTERNAL_SERVER_ERROR")
+      );
+    }
+    return listByResourceType({ ...input, limit: 200, paginationToken })
+      .mapErr(convertStampHubError)
+      .andThen((result) => {
+        result.items.forEach((item) => acc.set(item.id, item));
+        if (result.paginationToken) {
+          return collect(input, result.paginationToken, acc, page + 1);
+        }
+        return okAsync(acc);
+      });
+  };
+  return (input) => collect(input, undefined, new Map<ResourceId, ResourceOnDB>(), 0);
+}

--- a/packages/hub/src/events/resource/requester/isRequesterOfResource.test.ts
+++ b/packages/hub/src/events/resource/requester/isRequesterOfResource.test.ts
@@ -1,0 +1,44 @@
+import { none, some } from "@stamp-lib/stamp-option";
+import { errAsync, okAsync } from "neverthrow";
+import { describe, expect, it, vi } from "vitest";
+import { StampHubError } from "../../../error";
+import { IsUserInGroup } from "../../group/membership";
+import { createIsRequesterOfResource } from "./isRequesterOfResource";
+
+const userId = "47f29c51-204c-09f6-2069-f3df073568c7";
+const groupA = "1f10d463-a2fe-c407-2b95-05b561346c8b";
+const groupB = "7c2b9e4d-1a3f-4c5e-9b8a-6d5c4b3a2f1e";
+
+const memberOf =
+  (groups: Array<string>): IsUserInGroup =>
+  ({ groupId }) =>
+    okAsync(groups.includes(groupId));
+
+describe("createIsRequesterOfResource", () => {
+  it("returns true when the resource has no DB row", async () => {
+    const result = await createIsRequesterOfResource(memberOf([]))({ requestUserId: userId, resourceOnDB: none });
+    expect(result._unsafeUnwrap()).toBe(true);
+  });
+
+  it("returns true when requesterGroupIds is undefined or empty", async () => {
+    const isRequester = createIsRequesterOfResource(memberOf([]));
+    expect((await isRequester({ requestUserId: userId, resourceOnDB: some({}) }))._unsafeUnwrap()).toBe(true);
+    expect((await isRequester({ requestUserId: userId, resourceOnDB: some({ requesterGroupIds: [] }) }))._unsafeUnwrap()).toBe(true);
+  });
+
+  it("returns true when the user is in at least one requester group", async () => {
+    const result = await createIsRequesterOfResource(memberOf([groupB]))({ requestUserId: userId, resourceOnDB: some({ requesterGroupIds: [groupA, groupB] }) });
+    expect(result._unsafeUnwrap()).toBe(true);
+  });
+
+  it("returns false when the user is in none of the requester groups", async () => {
+    const result = await createIsRequesterOfResource(memberOf([]))({ requestUserId: userId, resourceOnDB: some({ requesterGroupIds: [groupA, groupB] }) });
+    expect(result._unsafeUnwrap()).toBe(false);
+  });
+
+  it("propagates membership lookup errors", async () => {
+    const failing: IsUserInGroup = vi.fn().mockReturnValue(errAsync(new StampHubError("boom", "boom", "INTERNAL_SERVER_ERROR")));
+    const result = await createIsRequesterOfResource(failing)({ requestUserId: userId, resourceOnDB: some({ requesterGroupIds: [groupA] }) });
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/hub/src/events/resource/requester/isRequesterOfResource.ts
+++ b/packages/hub/src/events/resource/requester/isRequesterOfResource.ts
@@ -1,0 +1,31 @@
+import { Option } from "@stamp-lib/stamp-option";
+import { ResourceOnDB } from "@stamp-lib/stamp-types/models";
+import { UserId } from "@stamp-lib/stamp-types/pluginInterface/identity";
+import { ResultAsync, okAsync } from "neverthrow";
+import { StampHubError } from "../../../error";
+import { IsUserInGroup } from "../../group/membership";
+
+export type IsRequesterOfResourceInput = {
+  requestUserId: UserId;
+  resourceOnDB: Option<Pick<ResourceOnDB, "requesterGroupIds">>;
+};
+export type IsRequesterOfResource = (input: IsRequesterOfResourceInput) => ResultAsync<boolean, StampHubError>;
+
+/**
+ * Whether the user may submit approval requests for the resource.
+ * No DB row, or no / empty `requesterGroupIds`, means anyone can request.
+ */
+export function createIsRequesterOfResource(isUserInGroup: IsUserInGroup): IsRequesterOfResource {
+  return ({ requestUserId, resourceOnDB }) => {
+    if (resourceOnDB.isNone()) {
+      return okAsync(true);
+    }
+    const requesterGroupIds = resourceOnDB.value.requesterGroupIds;
+    if (requesterGroupIds === undefined || requesterGroupIds.length === 0) {
+      return okAsync(true);
+    }
+    return ResultAsync.combine(requesterGroupIds.map((groupId) => isUserInGroup({ groupId, userId: requestUserId }))).map((results) =>
+      results.some((isMember) => isMember)
+    );
+  };
+}

--- a/packages/hub/src/events/resource/visibility/canViewResource.test.ts
+++ b/packages/hub/src/events/resource/visibility/canViewResource.test.ts
@@ -1,0 +1,201 @@
+import { none, some } from "@stamp-lib/stamp-option";
+import { ResourceOnDB } from "@stamp-lib/stamp-types/models";
+import { okAsync } from "neverthrow";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createCheckCanViewResource, createPrepareResourceVisibilityFilter, isResourceVisibleTo } from "./canViewResource";
+
+const userId = "47f29c51-204c-09f6-2069-f3df073568c7";
+const catalogOwnerGroupId = "0a3d8d5b-7a3f-4b2e-9c1d-2f4e6a8b0c1d";
+const ownerGroupId = "96fc6a4c-b5d3-8c2b-0307-165168a023cd";
+const approverGroupId = "18578bed-c45d-4f67-b9f7-10daf4c85f3f";
+const requesterGroupId = "1f10d463-a2fe-c407-2b95-05b561346c8b";
+const parentOwnerGroupId = "5e8f1c2a-3b4d-4e5f-8a9b-0c1d2e3f4a5b";
+const unrelatedGroupId = "7c2b9e4d-1a3f-4c5e-9b8a-6d5c4b3a2f1e";
+
+const catalogId = "test-catalog-id";
+const resourceTypeId = "test-resource-type-id";
+const parentResourceTypeId = "test-parent-resource-type-id";
+const resourceId = "res-1";
+const parentResourceId = "parent-1";
+
+const restrictedRow: ResourceOnDB = {
+  id: resourceId,
+  catalogId,
+  resourceTypeId,
+  ownerGroupId,
+  approverGroupId,
+  requesterGroupIds: [requesterGroupId],
+  visibility: "restricted",
+};
+const parentRow: ResourceOnDB = { id: parentResourceId, catalogId, resourceTypeId: parentResourceTypeId, ownerGroupId: parentOwnerGroupId };
+
+const viewer = (groups: Array<string>, isCatalogOwner = false) => ({ userGroupIds: new Set(groups), isCatalogOwner });
+
+describe("isResourceVisibleTo", () => {
+  it("is visible to everyone when there is no DB row or visibility is not restricted", () => {
+    expect(isResourceVisibleTo({ resourceOnDB: none, viewer: viewer([]) })).toBe(true);
+    expect(isResourceVisibleTo({ resourceOnDB: some({ ...restrictedRow, visibility: undefined }), viewer: viewer([]) })).toBe(true);
+    expect(isResourceVisibleTo({ resourceOnDB: some({ ...restrictedRow, visibility: "all" }), viewer: viewer([]) })).toBe(true);
+  });
+
+  it.each([
+    ["catalog owner", viewer([], true)],
+    ["owner group member", viewer([ownerGroupId])],
+    ["approver group member", viewer([approverGroupId])],
+    ["requester group member", viewer([requesterGroupId])],
+  ])("restricted resource is visible to %s", (_label, v) => {
+    expect(isResourceVisibleTo({ resourceOnDB: some(restrictedRow), viewer: v })).toBe(true);
+  });
+
+  it("restricted resource is visible to the parent owner when parentOwnerGroupId is given", () => {
+    expect(isResourceVisibleTo({ resourceOnDB: some(restrictedRow), parentOwnerGroupId, viewer: viewer([parentOwnerGroupId]) })).toBe(true);
+    expect(isResourceVisibleTo({ resourceOnDB: some(restrictedRow), viewer: viewer([parentOwnerGroupId]) })).toBe(false);
+  });
+
+  it("restricted resource is hidden from unrelated users", () => {
+    expect(isResourceVisibleTo({ resourceOnDB: some(restrictedRow), parentOwnerGroupId, viewer: viewer([unrelatedGroupId]) })).toBe(false);
+  });
+});
+
+function membershipOf(groups: Array<string>) {
+  return vi.fn().mockReturnValue(okAsync({ items: groups.map((groupId) => ({ groupId, userId, role: "member", createdAt: "", updatedAt: "" })) }));
+}
+const catalogDBWithOwner = vi.fn().mockReturnValue(okAsync(some({ id: catalogId, ownerGroupId: catalogOwnerGroupId })));
+
+describe("createCheckCanViewResource", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("passes unrestricted resources without any identity or catalog lookup", async () => {
+    const listByUser = membershipOf([]);
+    const getResourceDB = vi.fn();
+    const check = createCheckCanViewResource({ getResourceDB, getCatalogDB: catalogDBWithOwner, listGroupMemberShipByUser: listByUser });
+    const result = await check({ requestUserId: userId, catalogId, resourceOnDB: some({ ...restrictedRow, visibility: undefined }) });
+    expect(result.isOk()).toBe(true);
+    expect(listByUser).not.toHaveBeenCalled();
+    expect(catalogDBWithOwner).not.toHaveBeenCalled();
+    expect(getResourceDB).not.toHaveBeenCalled();
+  });
+
+  it("passes members of owner / approver / requester groups and the catalog owner", async () => {
+    for (const groups of [[ownerGroupId], [approverGroupId], [requesterGroupId], [catalogOwnerGroupId]]) {
+      const check = createCheckCanViewResource({ getResourceDB: vi.fn(), getCatalogDB: catalogDBWithOwner, listGroupMemberShipByUser: membershipOf(groups) });
+      const result = await check({ requestUserId: userId, catalogId, resourceOnDB: some(restrictedRow) });
+      expect(result.isOk()).toBe(true);
+    }
+  });
+
+  it("consults the parent only when no other rule matched, and passes the parent owner", async () => {
+    const getResourceDB = vi.fn().mockReturnValue(okAsync(some(parentRow)));
+    const resolveParent = vi.fn().mockReturnValue(okAsync(some({ resourceTypeId: parentResourceTypeId, resourceId: parentResourceId })));
+    const check = createCheckCanViewResource({ getResourceDB, getCatalogDB: catalogDBWithOwner, listGroupMemberShipByUser: membershipOf([parentOwnerGroupId]) });
+    const result = await check({ requestUserId: userId, catalogId, resourceOnDB: some(restrictedRow), resolveParent });
+    expect(result.isOk()).toBe(true);
+    expect(resolveParent).toHaveBeenCalledTimes(1);
+    expect(getResourceDB).toHaveBeenCalledWith({ id: parentResourceId, catalogId, resourceTypeId: parentResourceTypeId });
+  });
+
+  it("does not resolve the parent when the viewer already matches", async () => {
+    const resolveParent = vi.fn();
+    const check = createCheckCanViewResource({ getResourceDB: vi.fn(), getCatalogDB: catalogDBWithOwner, listGroupMemberShipByUser: membershipOf([ownerGroupId]) });
+    await check({ requestUserId: userId, catalogId, resourceOnDB: some(restrictedRow), resolveParent });
+    expect(resolveParent).not.toHaveBeenCalled();
+  });
+
+  it("returns FORBIDDEN for unrelated users (with and without a parent)", async () => {
+    const withParent = createCheckCanViewResource({
+      getResourceDB: vi.fn().mockReturnValue(okAsync(some(parentRow))),
+      getCatalogDB: catalogDBWithOwner,
+      listGroupMemberShipByUser: membershipOf([unrelatedGroupId]),
+    });
+    const r1 = await withParent({
+      requestUserId: userId,
+      catalogId,
+      resourceOnDB: some(restrictedRow),
+      resolveParent: () => okAsync(some({ resourceTypeId: parentResourceTypeId, resourceId: parentResourceId })),
+    });
+    expect(r1._unsafeUnwrapErr().code).toBe("FORBIDDEN");
+
+    const withoutParent = createCheckCanViewResource({ getResourceDB: vi.fn(), getCatalogDB: catalogDBWithOwner, listGroupMemberShipByUser: membershipOf([unrelatedGroupId]) });
+    const r2 = await withoutParent({ requestUserId: userId, catalogId, resourceOnDB: some(restrictedRow) });
+    expect(r2._unsafeUnwrapErr().code).toBe("FORBIDDEN");
+    const r3 = await withoutParent({ requestUserId: userId, catalogId, resourceOnDB: some(restrictedRow), resolveParent: () => okAsync(none) });
+    expect(r3._unsafeUnwrapErr().code).toBe("FORBIDDEN");
+  });
+});
+
+describe("createPrepareResourceVisibilityFilter", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const rowsByType = (rows: Array<ResourceOnDB>, parents: Array<ResourceOnDB> = []) =>
+    vi.fn().mockImplementation((input: { resourceTypeId: string }) => okAsync({ items: input.resourceTypeId === parentResourceTypeId ? parents : rows }));
+
+  it("shows everything without identity lookups when no row is restricted", async () => {
+    const listByUser = membershipOf([]);
+    const listResourceByResourceType = rowsByType([{ ...restrictedRow, visibility: undefined }]);
+    const prepare = createPrepareResourceVisibilityFilter({ listResourceByResourceType, getCatalogDB: catalogDBWithOwner, listGroupMemberShipByUser: listByUser });
+    const isVisible = (await prepare({ requestUserId: userId, catalogId, resourceTypeId, parentResourceTypeId }))._unsafeUnwrap();
+    expect(isVisible({ id: resourceId })).toBe(true);
+    expect(isVisible({ id: "other" })).toBe(true);
+    expect(listResourceByResourceType).toHaveBeenCalledTimes(1);
+    expect(listByUser).not.toHaveBeenCalled();
+  });
+
+  it("shows everything to the catalog owner without loading parent rows", async () => {
+    const listResourceByResourceType = rowsByType([restrictedRow], [parentRow]);
+    const prepare = createPrepareResourceVisibilityFilter({
+      listResourceByResourceType,
+      getCatalogDB: catalogDBWithOwner,
+      listGroupMemberShipByUser: membershipOf([catalogOwnerGroupId]),
+    });
+    const isVisible = (await prepare({ requestUserId: userId, catalogId, resourceTypeId, parentResourceTypeId }))._unsafeUnwrap();
+    expect(isVisible({ id: resourceId })).toBe(true);
+    expect(listResourceByResourceType).toHaveBeenCalledTimes(1);
+  });
+
+  it("filters restricted rows for unrelated users but keeps unrestricted ones", async () => {
+    const listResourceByResourceType = rowsByType([restrictedRow], [parentRow]);
+    const prepare = createPrepareResourceVisibilityFilter({
+      listResourceByResourceType,
+      getCatalogDB: catalogDBWithOwner,
+      listGroupMemberShipByUser: membershipOf([unrelatedGroupId]),
+    });
+    const isVisible = (await prepare({ requestUserId: userId, catalogId, resourceTypeId, parentResourceTypeId }))._unsafeUnwrap();
+    expect(isVisible({ id: resourceId, parentResourceId })).toBe(false);
+    expect(isVisible({ id: "no-row-resource" })).toBe(true);
+    // type rows + parent type rows
+    expect(listResourceByResourceType).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows restricted rows to requester members and to the parent owner", async () => {
+    const listResourceByResourceType = rowsByType([restrictedRow], [parentRow]);
+    const asRequester = createPrepareResourceVisibilityFilter({
+      listResourceByResourceType,
+      getCatalogDB: catalogDBWithOwner,
+      listGroupMemberShipByUser: membershipOf([requesterGroupId]),
+    });
+    expect((await asRequester({ requestUserId: userId, catalogId, resourceTypeId, parentResourceTypeId }))._unsafeUnwrap()({ id: resourceId })).toBe(true);
+
+    const asParentOwner = createPrepareResourceVisibilityFilter({
+      listResourceByResourceType,
+      getCatalogDB: catalogDBWithOwner,
+      listGroupMemberShipByUser: membershipOf([parentOwnerGroupId]),
+    });
+    const isVisible = (await asParentOwner({ requestUserId: userId, catalogId, resourceTypeId, parentResourceTypeId }))._unsafeUnwrap();
+    expect(isVisible({ id: resourceId, parentResourceId })).toBe(true);
+    expect(isVisible({ id: resourceId })).toBe(false); // no parent id on the item -> parent rule cannot apply
+  });
+
+  it("reflects rows from a second page of listByResourceType", async () => {
+    const listResourceByResourceType = vi
+      .fn()
+      .mockReturnValueOnce(okAsync({ items: [], paginationToken: "t1" }))
+      .mockReturnValueOnce(okAsync({ items: [restrictedRow] }));
+    const prepare = createPrepareResourceVisibilityFilter({
+      listResourceByResourceType,
+      getCatalogDB: catalogDBWithOwner,
+      listGroupMemberShipByUser: membershipOf([unrelatedGroupId]),
+    });
+    const isVisible = (await prepare({ requestUserId: userId, catalogId, resourceTypeId }))._unsafeUnwrap();
+    expect(isVisible({ id: resourceId })).toBe(false);
+  });
+});

--- a/packages/hub/src/events/resource/visibility/canViewResource.ts
+++ b/packages/hub/src/events/resource/visibility/canViewResource.ts
@@ -1,0 +1,167 @@
+import { Option, none, some } from "@stamp-lib/stamp-option";
+import { CatalogId, ResourceId, ResourceOnDB, ResourceTypeId } from "@stamp-lib/stamp-types/models";
+import { CatalogDBProvider, ResourceDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { GroupId, GroupMemberShipProvider, UserId } from "@stamp-lib/stamp-types/pluginInterface/identity";
+import { ResultAsync, errAsync, okAsync } from "neverthrow";
+import { StampHubError, convertStampHubError } from "../../../error";
+import { createIsCatalogOwner } from "../../catalog/ownership/isCatalogOwner";
+import { createIsUserInGroupFromSet, createListAllGroupIdsByUser } from "../../group/membership";
+import { createListAllResourceOnDBByType } from "../info/listAllResourceOnDBByType";
+
+export type ResourceVisibilityViewer = {
+  /** Every group id the viewer belongs to. */
+  userGroupIds: ReadonlySet<GroupId>;
+  /** Whether the viewer is an owner of the catalog the resource belongs to. */
+  isCatalogOwner: boolean;
+};
+
+/**
+ * Whether a resource is restricted (needs a visibility check at all).
+ */
+export function isRestrictedResource(resourceOnDB: Option<Pick<ResourceOnDB, "visibility">>): boolean {
+  return resourceOnDB.isSome() && resourceOnDB.value.visibility === "restricted";
+}
+
+/**
+ * Pure visibility rule.
+ * - No DB row or visibility !== "restricted": visible to everyone.
+ * - restricted: visible to the catalog owner, members of ownerGroupId / approverGroupId / requesterGroupIds,
+ *   and members of the parent resource's ownerGroupId.
+ */
+export function isResourceVisibleTo(input: {
+  resourceOnDB: Option<ResourceOnDB>;
+  parentOwnerGroupId?: GroupId;
+  viewer: ResourceVisibilityViewer;
+}): boolean {
+  const { resourceOnDB, parentOwnerGroupId, viewer } = input;
+  if (!isRestrictedResource(resourceOnDB) || resourceOnDB.isNone()) {
+    return true;
+  }
+  if (viewer.isCatalogOwner) {
+    return true;
+  }
+  const resource = resourceOnDB.value;
+  if (resource.ownerGroupId && viewer.userGroupIds.has(resource.ownerGroupId)) {
+    return true;
+  }
+  if (resource.approverGroupId && viewer.userGroupIds.has(resource.approverGroupId)) {
+    return true;
+  }
+  if (resource.requesterGroupIds?.some((groupId) => viewer.userGroupIds.has(groupId))) {
+    return true;
+  }
+  if (parentOwnerGroupId && viewer.userGroupIds.has(parentOwnerGroupId)) {
+    return true;
+  }
+  return false;
+}
+
+export type ResourceVisibilityDeps = {
+  getCatalogDB: CatalogDBProvider["getById"];
+  listGroupMemberShipByUser: GroupMemberShipProvider["listByUser"];
+};
+
+/**
+ * Resolve the viewer's group set and catalog ownership with a constant number of lookups.
+ */
+export function createResolveResourceVisibilityViewer(deps: ResourceVisibilityDeps) {
+  const listAllGroupIdsByUser = createListAllGroupIdsByUser(deps.listGroupMemberShipByUser);
+  return (input: { requestUserId: UserId; catalogId: CatalogId }): ResultAsync<ResourceVisibilityViewer, StampHubError> =>
+    listAllGroupIdsByUser(input.requestUserId).andThen((userGroupIds) =>
+      createIsCatalogOwner(deps.getCatalogDB, createIsUserInGroupFromSet(userGroupIds))(input).map((isCatalogOwner) => ({ userGroupIds, isCatalogOwner }))
+    );
+}
+
+export type ParentResourceKey = { resourceTypeId: ResourceTypeId; resourceId: ResourceId };
+
+export type CheckCanViewResourceInput = {
+  requestUserId: UserId;
+  catalogId: CatalogId;
+  resourceOnDB: Option<ResourceOnDB>;
+  /**
+   * Resolves the parent resource key. Called only when the resource is restricted and no other rule matched,
+   * so callers may back it with a catalog handler call.
+   */
+  resolveParent?: () => ResultAsync<Option<ParentResourceKey>, StampHubError>;
+};
+export type CheckCanViewResource = (input: CheckCanViewResourceInput) => ResultAsync<void, StampHubError>;
+
+const permissionDenied = () => new StampHubError("Permission denied", "Permission Denied", "FORBIDDEN");
+
+/**
+ * Single-resource visibility check (resource.get / resource.listAuditItem). Returns FORBIDDEN when not visible.
+ * Unrestricted resources short-circuit without any identity / catalog lookup.
+ */
+export function createCheckCanViewResource(deps: ResourceVisibilityDeps & { getResourceDB: ResourceDBProvider["getById"] }): CheckCanViewResource {
+  const resolveViewer = createResolveResourceVisibilityViewer(deps);
+  return (input) => {
+    if (!isRestrictedResource(input.resourceOnDB)) {
+      return okAsync(undefined);
+    }
+    return resolveViewer({ requestUserId: input.requestUserId, catalogId: input.catalogId }).andThen((viewer) => {
+      if (isResourceVisibleTo({ resourceOnDB: input.resourceOnDB, viewer })) {
+        return okAsync(undefined);
+      }
+      if (!input.resolveParent) {
+        return errAsync(permissionDenied());
+      }
+      return input.resolveParent().andThen((parentKey) => {
+        if (parentKey.isNone()) {
+          return errAsync(permissionDenied());
+        }
+        return deps
+          .getResourceDB({ id: parentKey.value.resourceId, catalogId: input.catalogId, resourceTypeId: parentKey.value.resourceTypeId })
+          .mapErr(convertStampHubError)
+          .andThen((parentOnDB) => {
+            const parentOwnerGroupId = parentOnDB.isSome() ? parentOnDB.value.ownerGroupId : undefined;
+            if (isResourceVisibleTo({ resourceOnDB: input.resourceOnDB, parentOwnerGroupId, viewer })) {
+              return okAsync(undefined);
+            }
+            return errAsync(permissionDenied());
+          });
+      });
+    });
+  };
+}
+
+export type ResourceVisibilityFilter = (item: { id: ResourceId; parentResourceId?: ResourceId }) => boolean;
+
+/**
+ * Build a synchronous visibility filter for a whole list page of one resource type with a constant number of reads:
+ * 1 Query for the type's rows (+1 for the parent type), and identity / catalog lookups only if some row is restricted.
+ */
+export function createPrepareResourceVisibilityFilter(deps: ResourceVisibilityDeps & { listResourceByResourceType: ResourceDBProvider["listByResourceType"] }) {
+  const listAllResourceOnDBByType = createListAllResourceOnDBByType(deps.listResourceByResourceType);
+  const resolveViewer = createResolveResourceVisibilityViewer(deps);
+  const showAll: ResourceVisibilityFilter = () => true;
+
+  return (input: {
+    requestUserId: UserId;
+    catalogId: CatalogId;
+    resourceTypeId: ResourceTypeId;
+    parentResourceTypeId?: ResourceTypeId;
+  }): ResultAsync<ResourceVisibilityFilter, StampHubError> => {
+    return listAllResourceOnDBByType({ catalogId: input.catalogId, resourceTypeId: input.resourceTypeId }).andThen((rows) => {
+      const hasRestricted = Array.from(rows.values()).some((row) => row.visibility === "restricted");
+      if (!hasRestricted) {
+        return okAsync(showAll);
+      }
+      return resolveViewer({ requestUserId: input.requestUserId, catalogId: input.catalogId }).andThen((viewer) => {
+        if (viewer.isCatalogOwner) {
+          return okAsync(showAll);
+        }
+        const parentRows =
+          input.parentResourceTypeId !== undefined
+            ? listAllResourceOnDBByType({ catalogId: input.catalogId, resourceTypeId: input.parentResourceTypeId })
+            : okAsync(new Map<ResourceId, ResourceOnDB>());
+        return parentRows.map((parents): ResourceVisibilityFilter => {
+          return (item) => {
+            const row = rows.get(item.id);
+            const parentOwnerGroupId = item.parentResourceId !== undefined ? parents.get(item.parentResourceId)?.ownerGroupId : undefined;
+            return isResourceVisibleTo({ resourceOnDB: row === undefined ? none : some(row), parentOwnerGroupId, viewer });
+          };
+        });
+      });
+    });
+  };
+}

--- a/packages/hub/src/inputAuthzModel.ts
+++ b/packages/hub/src/inputAuthzModel.ts
@@ -22,7 +22,7 @@ import {
   UpdateResourceVisibilityInput as WorkflowUpdateResourceVisibilityInput,
 } from "./workflows/resource/input";
 import { UserId } from "@stamp-lib/stamp-types/pluginInterface/identity";
-import { ApprovalFlowInfo } from "@stamp-lib/stamp-types/models";
+import { ApprovalFlowId, ApprovalFlowInfo, ApprovalRequestInputResource, CatalogId } from "@stamp-lib/stamp-types/models";
 
 export const EditUserInput = DeleteUserInput;
 export type EditUserInput = z.infer<typeof EditUserInput>;
@@ -65,7 +65,12 @@ export type UpdateResourceVisibilityInput = z.infer<typeof UpdateResourceVisibil
 export const EditApprovalFlowInput = z.object({ catalogId: z.string(), approvalFlowId: z.string(), requestUserId: UserId });
 export type EditApprovalFlowInput = z.infer<typeof EditApprovalFlowInput>;
 
-export const SubmitApprovalRequestInput = z.object({ catalogId: z.string(), approvalFlowId: z.string(), requestUserId: UserId });
+export const SubmitApprovalRequestInput = z.object({
+  catalogId: CatalogId,
+  approvalFlowId: ApprovalFlowId,
+  requestUserId: UserId,
+  inputResources: z.array(ApprovalRequestInputResource).max(5),
+});
 export type SubmitApprovalRequestInput = z.infer<typeof SubmitApprovalRequestInput>;
 
 export const ApproveApprovalRequestInput = z.object({ catalogId: z.string(), approvalFlowId: z.string(), userIdWhoApproved: UserId });

--- a/packages/hub/src/route/userRequest/approvalRequest.ts
+++ b/packages/hub/src/route/userRequest/approvalRequest.ts
@@ -27,6 +27,7 @@ export const approvalRequestRouter = router({
         getApprovalFlowById: ctx.db.approvalFlowDB.getById,
         getResourceById: ctx.db.resourceDB.getById,
         getGroup: ctx.identity.group.get,
+        getGroupMemberShip: ctx.identity.groupMemberShip.get,
         getNotificationPluginConfig: ctx.config.notificationPlugin.get,
         createSchedulerEvent: ctx.scheduler?.createSchedulerEvent,
       },

--- a/packages/hub/src/route/userRequest/resource.ts
+++ b/packages/hub/src/route/userRequest/resource.ts
@@ -46,6 +46,8 @@ export const resourceRouter = router({
     const getResourceResult = await getResourceInfo({
       getCatalogConfigProvider: ctx.config.catalogConfig.get,
       getResourceDBProvider: ctx.db.resourceDB.getById,
+      getCatalogDBProvider: ctx.db.catalogDB.getById,
+      listGroupMemberShipByUser: ctx.identity.groupMemberShip.listByUser,
     })(input)
       .andThen(unwrapOptionOrThrowNotFound)
       .mapErr(convertTRPCError(logger));
@@ -87,6 +89,7 @@ export const resourceRouter = router({
           getNotificationPluginConfig: ctx.config.notificationPlugin.get,
           createSchedulerEvent: ctx.scheduler?.createSchedulerEvent,
           getGroup: ctx.identity.group.get,
+          getGroupMemberShip: ctx.identity.groupMemberShip.get,
         },
         logger
       )
@@ -136,7 +139,12 @@ export const resourceRouter = router({
   }),
   listOutlines: publicProcedure.input(ListResourceOutlinesInput).query(async ({ input, ctx }) => {
     const logger = createStampHubLogger();
-    const listResourceOutlinesResult = await listResourceOutlines({ catalogConfigProvider: ctx.config.catalogConfig })(input).mapErr(convertTRPCError(logger));
+    const listResourceOutlinesResult = await listResourceOutlines({
+      catalogConfigProvider: ctx.config.catalogConfig,
+      catalogDBProvider: ctx.db.catalogDB,
+      resourceDBProvider: ctx.db.resourceDB,
+      listGroupMemberShipByUser: ctx.identity.groupMemberShip.listByUser,
+    })(input).mapErr(convertTRPCError(logger));
     return unwrapOrthrowTRPCError(listResourceOutlinesResult);
   }),
   updateApprover: publicProcedure.input(UpdateResourceApproverInput).mutation(async ({ input, ctx }) => {
@@ -182,7 +190,12 @@ export const resourceRouter = router({
   }),
   listAuditItem: publicProcedure.input(ListResourceAuditItemInput).query(async ({ input, ctx }) => {
     const logger = createStampHubLogger();
-    const listResourceAuditItemResult = await listResourceAuditItem(logger, ctx.config.catalogConfig.get)(input).mapErr(convertTRPCError(logger));
+    const listResourceAuditItemResult = await listResourceAuditItem(logger, {
+      getCatalogConfigProvider: ctx.config.catalogConfig.get,
+      getResourceDBProvider: ctx.db.resourceDB.getById,
+      getCatalogDBProvider: ctx.db.catalogDB.getById,
+      listGroupMemberShipByUser: ctx.identity.groupMemberShip.listByUser,
+    })(input).mapErr(convertTRPCError(logger));
     return unwrapOrthrowTRPCError(listResourceAuditItemResult);
   }),
   createAuditNotification: publicProcedure.input(CreateAuditNotificationInput).mutation(async ({ input, ctx }) => {

--- a/packages/hub/src/system-catalog/approval-flows/resource-update.ts
+++ b/packages/hub/src/system-catalog/approval-flows/resource-update.ts
@@ -13,7 +13,7 @@ import { createStampHubLogger } from "../../logger";
 import { CatalogConfigProvider } from "@stamp-lib/stamp-types/configInterface";
 import { createGetCatalogConfig } from "../../events/catalog/catalogConfig";
 import { convertPromiseResultToResultAsync } from "../../utils/neverthrow";
-import { GetResourceInfo, getResourceInfo } from "../../workflows/resource/getResourceInfo";
+import { GetResourceInfo, getResourceInfoWithoutVisibilityCheck } from "../../workflows/resource/getResourceInfo";
 import { Logger } from "@stamp-lib/stamp-logger";
 import { StampHubError } from "../../error";
 
@@ -50,7 +50,7 @@ export const createCheckCanApproveResourceUpdate = (
   resourceDBProvider: ResourceDBProvider
 ): CheckCanApproveResourceUpdate => {
   return checkCanApproveResourceUpdate({
-    getResourceInfo: getResourceInfo({
+    getResourceInfo: getResourceInfoWithoutVisibilityCheck({
       getCatalogConfigProvider: catalogConfigProvider.get,
       getResourceDBProvider: resourceDBProvider.getById,
     }),

--- a/packages/hub/src/workflows/approval-request/approve.test.ts
+++ b/packages/hub/src/workflows/approval-request/approve.test.ts
@@ -1354,4 +1354,97 @@ describe("approveWorkflow", () => {
       });
     });
   });
+  describe("requester re-check", () => {
+    const requesterGroupId = "1f10d463-a2fe-c407-2b95-05b561346c8b";
+    const approverGroupId = "18578bed-c45d-4f67-b9f7-10daf4c85f3f";
+    const requestUserId = "dbf33b00-8a5f-e045-4aa1-2d943cb659b6";
+    const userIdWhoApproved = "13f6d758-cea9-bfab-ffaf-9e012ddacf47";
+    const pendingRequest = {
+      requestId: "38296685-5f00-ca43-5e7a-218e9eb7b423",
+      requestDate: new Date().toISOString(),
+      approvalFlowId: "test-approval-flow-id",
+      requestUserId,
+      approverId: approverGroupId,
+      inputParams: [],
+      inputResources: [{ resourceId: "test-resource-id", resourceTypeId: "test-resource-type-id" }],
+      status: "pending",
+      catalogId: "test-catalog-id",
+      approverType: "group",
+      requestComment: "test request comment",
+      validatedDate: new Date().toISOString(),
+      validationHandlerResult: { isSuccess: true, message: "ok" },
+    };
+    const buildProviders = (requesterStillMember: boolean) => {
+      // Created per test because the outer beforeEach resets all mocks.
+      const testApprovalFlowHandler: ApprovalFlowHandler = {
+        approvalRequestValidation: vi.fn(),
+        approved: vi.fn().mockResolvedValue(ok({ isSuccess: true, message: "approved Actions Succeeded" })),
+        revoked: vi.fn(),
+      };
+      const getGroupMemberShip: GroupMemberShipProvider["get"] = vi.fn().mockImplementation(({ groupId, userId }) => {
+        if (groupId === approverGroupId && userId === userIdWhoApproved) {
+          return okAsync(some({ groupId, userId, role: "owner", createdAt: "", updatedAt: "" }));
+        }
+        if (groupId === requesterGroupId && userId === requestUserId && requesterStillMember) {
+          return okAsync(some({ groupId, userId, role: "member", createdAt: "", updatedAt: "" }));
+        }
+        return okAsync(none);
+      });
+      const updateApprovalRequestStatusToApproved: ApprovalRequestDBProvider["updateStatusToApproved"] = vi
+        .fn()
+        .mockReturnValue(okAsync({ ...pendingRequest, status: "approved", approvedDate: new Date().toISOString(), userIdWhoApproved, approvedComment: "c" }));
+      return {
+        getCatalogConfigProvider: vi.fn().mockReturnValue(
+          okAsync(
+            some({
+              id: "test-catalog-id",
+              name: "test-catalog",
+              description: "catalogDescription",
+              approvalFlows: [
+                {
+                  id: "test-approval-flow-id",
+                  name: "n",
+                  description: "d",
+                  inputParams: [],
+                  handlers: testApprovalFlowHandler,
+                  inputResources: [],
+                  approver: { approverType: "approvalFlow" },
+                },
+              ],
+              resourceTypes: [],
+            })
+          )
+        ) as CatalogConfigProvider["get"],
+        getApprovalRequestById: vi.fn().mockReturnValue(okAsync(some(pendingRequest))) as ApprovalRequestDBProvider["getById"],
+        updateApprovalRequestStatusToApproved,
+        setApprovalRequest: vi.fn().mockImplementation((input) => okAsync(input)) as ApprovalRequestDBProvider["set"],
+        getApprovalFlowById: vi
+          .fn()
+          .mockReturnValue(okAsync(some({ id: "test-approval-flow-id", catalogId: "test-catalog-id", approverGroupId }))) as ApprovalFlowDBProvider["getById"],
+        getResourceById: vi
+          .fn()
+          .mockReturnValue(
+            okAsync(some({ id: "test-resource-id", catalogId: "test-catalog-id", resourceTypeId: "test-resource-type-id", requesterGroupIds: [requesterGroupId] }))
+          ) as ResourceDBProvider["getById"],
+        getGroupMemberShip,
+      };
+    };
+    const input: ApproveWorkflowInput = { approvalRequestId: pendingRequest.requestId, approvedComment: "c", userIdWhoApproved };
+
+    it("rejects approval with BAD_REQUEST when the requester is no longer in requesterGroupIds", async () => {
+      const providers = buildProviders(false);
+      const result = await approveWorkflow(providers, logger)(input);
+      const error = result._unsafeUnwrapErr();
+      expect(error.code).toBe("BAD_REQUEST");
+      expect(error.userMessage).toContain("no longer allowed");
+      expect(providers.updateApprovalRequestStatusToApproved).not.toHaveBeenCalled();
+    });
+
+    it("approves when the requester is still a member", async () => {
+      const providers = buildProviders(true);
+      const result = await approveWorkflow(providers, logger)(input);
+      expect(result._unsafeUnwrap().status).toBe("approvedActionSucceeded");
+      expect(providers.updateApprovalRequestStatusToApproved).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/hub/src/workflows/approval-request/approve.ts
+++ b/packages/hub/src/workflows/approval-request/approve.ts
@@ -19,6 +19,8 @@ import {
 import { CreateSchedulerEvent } from "@stamp-lib/stamp-types/pluginInterface/scheduler";
 import { settingAutoRevoke } from "../../events/approval-request/actions/autoRevoke";
 import { Logger } from "@stamp-lib/stamp-logger";
+import { createFindResourceNotRequestableBy } from "../../events/approval-request/authz/submit";
+import { inputResourcesOfApprovalRequest } from "../../events/approval-request/resources";
 
 export const ApproveWorkflowInput = z.object({ approvalRequestId: z.string(), approvedComment: z.string().max(1024), userIdWhoApproved: UserId });
 export type ApproveWorkflowInput = z.infer<typeof ApproveWorkflowInput>;
@@ -49,6 +51,7 @@ export const approveWorkflow =
       createSchedulerEvent,
     } = providers;
     const getCatalogConfig = createGetCatalogConfig(getCatalogConfigProvider);
+    const findResourceNotRequestableBy = createFindResourceNotRequestableBy(getResourceById, getGroupMemberShip);
 
     return parseZodObjectAsync(input, ApproveWorkflowInput)
       .andThen((parsedInput) => {
@@ -116,6 +119,25 @@ export const approveWorkflow =
           // Return Internal server error because approverType is only approvalFlow or resource.
           return errAsync(new StampHubError("Approver type not found", "Approver Type Not Found", "INTERNAL_SERVER_ERROR"));
         }
+      })
+      .andThen((extendApprovalRequest) => {
+        // Re-check that the requester is still allowed to request every input resource
+        // (requesterGroupIds may have been tightened after the request was submitted).
+        return findResourceNotRequestableBy(extendApprovalRequest.requestUserId, inputResourcesOfApprovalRequest(extendApprovalRequest)).andThen(
+          (notRequestable) => {
+            if (notRequestable.isNone()) {
+              return okAsync(extendApprovalRequest);
+            }
+            const ref = notRequestable.value;
+            return errAsync(
+              new StampHubError(
+                `Requester ${extendApprovalRequest.requestUserId} is no longer in requesterGroupIds of resource ${ref.resourceTypeId}/${ref.resourceId}`,
+                "Requester is no longer allowed to request this resource. Please reject the request.",
+                "BAD_REQUEST"
+              )
+            );
+          }
+        );
       })
       .andThen((extendApprovedRequest) => {
         // If autoRevokeDuration is set, create a scheduler event to revoke the request.

--- a/packages/hub/src/workflows/approval-request/submit.test.ts
+++ b/packages/hub/src/workflows/approval-request/submit.test.ts
@@ -73,6 +73,7 @@ describe("submitWorkflow", () => {
     ),
     getNotificationPluginConfig: vi.fn().mockReturnValue(okAsync(none)),
     createSchedulerEvent: vi.fn().mockReturnValue(okAsync({ id: "scheduler-event-id" })),
+    getGroupMemberShip: vi.fn().mockReturnValue(okAsync(none)),
   };
 
   it("should successfully submit approval request without autoRevokeDuration", async () => {
@@ -847,5 +848,114 @@ describe("submitWorkflow", () => {
     expect(result.isOk()).toBe(true);
     expect(result._unsafeUnwrap().status).toBe("pending");
     expect(sendNotificationMock).toHaveBeenCalled();
+  });
+  describe("requester authorization and visibility snapshot", () => {
+    const requesterGroupId = "1f10d463-a2fe-c407-2b95-05b561346c8b";
+    const ownerGroupId = "96fc6a4c-b5d3-8c2b-0307-165168a023cd";
+    const resourceHandlers = {
+      createResource: vi.fn(),
+      deleteResource: vi.fn(),
+      getResource: vi.fn().mockResolvedValue(ok(some({ resourceId: "test-resource-id", name: "r", params: {} }))),
+      listResources: vi.fn(),
+      updateResource: vi.fn(),
+      listResourceAuditItem: vi.fn(),
+    };
+    const catalogConfigWithResourceType = vi.fn().mockReturnValue(
+      okAsync(
+        some({
+          id: "test-catalog-id",
+          name: "test-catalog",
+          description: "catalogDescription",
+          approvalFlows: [
+            {
+              id: "test-approval-flow-id",
+              name: "testApprovalFlowName",
+              description: "testApprovalFlowDescription",
+              inputParams: [],
+              handlers: testApprovalFlowHandler,
+              inputResources: [{ resourceTypeId: "test-resource-type-id", description: "d" }],
+              approver: { approverType: "approvalFlow" },
+            },
+          ],
+          resourceTypes: [
+            {
+              id: "test-resource-type-id",
+              name: "t",
+              description: "t",
+              createParams: [],
+              infoParams: [],
+              handlers: resourceHandlers,
+              isCreatable: false,
+              isUpdatable: false,
+              isDeletable: false,
+              ownerManagement: true,
+              approverManagement: true,
+            },
+          ],
+        })
+      )
+    );
+    const input: SubmitWorkflowInput = {
+      approvalFlowId: "test-approval-flow-id",
+      requestUserId: "dbf33b00-8a5f-e045-4aa1-2d943cb659b6",
+      requestComment: "test request comment",
+      inputParams: [],
+      inputResources: [{ resourceTypeId: "test-resource-type-id", resourceId: "test-resource-id" }],
+      catalogId: "test-catalog-id",
+    };
+
+    it("rejects with FORBIDDEN and writes nothing when the requester is not in requesterGroupIds", async () => {
+      const mockProviders = {
+        ...defaultMockProviders,
+        getCatalogConfigProvider: catalogConfigWithResourceType,
+        getResourceById: vi
+          .fn()
+          .mockReturnValue(okAsync(some({ id: "test-resource-id", catalogId: "test-catalog-id", resourceTypeId: "test-resource-type-id", requesterGroupIds: [requesterGroupId] }))),
+        getGroupMemberShip: vi.fn().mockReturnValue(okAsync(none)),
+      };
+      const result = await submitWorkflow(mockProviders, logger)(input);
+      expect(result._unsafeUnwrapErr().code).toBe("FORBIDDEN");
+      expect(mockProviders.setApprovalRequestDBProvider).not.toHaveBeenCalled();
+      expect(mockProviders.getGroupMemberShip).toHaveBeenCalledWith({ groupId: requesterGroupId, userId: input.requestUserId });
+    });
+
+    it("submits when the requester is a member and stores a visibility snapshot for a restricted resource", async () => {
+      const mockProviders = {
+        ...defaultMockProviders,
+        getCatalogConfigProvider: catalogConfigWithResourceType,
+        getResourceById: vi.fn().mockReturnValue(
+          okAsync(
+            some({
+              id: "test-resource-id",
+              catalogId: "test-catalog-id",
+              resourceTypeId: "test-resource-type-id",
+              ownerGroupId,
+              requesterGroupIds: [requesterGroupId],
+              visibility: "restricted",
+            })
+          )
+        ),
+        getGroupMemberShip: vi.fn().mockReturnValue(okAsync(some({ groupId: requesterGroupId, userId: input.requestUserId, role: "member", createdAt: "", updatedAt: "" }))),
+      };
+      const result = await submitWorkflow(mockProviders, logger)(input);
+      expect(result._unsafeUnwrap().status).toBe("pending");
+      const stored = mockProviders.setApprovalRequestDBProvider.mock.calls[0][0];
+      expect(stored.visibility).toEqual({ type: "restricted", viewerGroupIds: [ownerGroupId, requesterGroupId] });
+    });
+
+    it("stores no visibility snapshot for unrestricted resources and ignores a client-supplied visibility", async () => {
+      const mockProviders = {
+        ...defaultMockProviders,
+        getCatalogConfigProvider: catalogConfigWithResourceType,
+        getResourceById: vi.fn().mockReturnValue(okAsync(some({ id: "test-resource-id", catalogId: "test-catalog-id", resourceTypeId: "test-resource-type-id", ownerGroupId }))),
+      };
+      const result = await submitWorkflow(mockProviders, logger)({
+        ...input,
+        visibility: { type: "restricted", viewerGroupIds: [ownerGroupId] },
+      } as unknown as SubmitWorkflowInput);
+      expect(result._unsafeUnwrap().status).toBe("pending");
+      const stored = mockProviders.setApprovalRequestDBProvider.mock.calls[0][0];
+      expect(stored.visibility).toBeUndefined();
+    });
   });
 });

--- a/packages/hub/src/workflows/approval-request/submit.ts
+++ b/packages/hub/src/workflows/approval-request/submit.ts
@@ -13,7 +13,9 @@ import { createSubmitApprovalRequest } from "../../events/approval-request/actio
 import { getApprovalFlowConfig } from "../../events/approval-flow/approvalFlowConfig";
 import { createValidateApprovalRequest } from "../../events/approval-request/actions/validate";
 import { enrichInputDataForNotification } from "../../events/approval-request/actions/enrichForNotification";
-import { GetGroup } from "@stamp-lib/stamp-types/pluginInterface/identity";
+import { GetGroup, GroupMemberShipProvider } from "@stamp-lib/stamp-types/pluginInterface/identity";
+import { checkCanSubmitRequestForResources } from "../../events/approval-request/authz/submit";
+import { createBuildRequestVisibility } from "../../events/approval-request/visibility/buildRequestVisibility";
 import { Logger } from "@stamp-lib/stamp-logger";
 import { validateAutoRevokeDurationTime } from "../../events/approval-request/actions/autoRevoke";
 import { CreateSchedulerEvent } from "@stamp-lib/stamp-types/pluginInterface/scheduler";
@@ -34,6 +36,7 @@ export const submitWorkflow =
       getApprovalFlowById: ApprovalFlowDBProvider["getById"];
       getResourceById: ResourceDBProvider["getById"];
       getGroup: GetGroup;
+      getGroupMemberShip: GroupMemberShipProvider["get"];
       getNotificationPluginConfig: GetNotificationPluginConfig;
       createSchedulerEvent?: CreateSchedulerEvent;
     },
@@ -46,16 +49,21 @@ export const submitWorkflow =
       getApprovalFlowById,
       getResourceById,
       getGroup,
+      getGroupMemberShip,
       getNotificationPluginConfig,
       createSchedulerEvent,
     } = providers;
 
     const getCatalogConfig = createGetCatalogConfig(getCatalogConfigProvider);
     const submitApprovalRequest = createSubmitApprovalRequest(setApprovalRequestDBProvider);
+    const checkCanSubmit = checkCanSubmitRequestForResources(getResourceById, getGroupMemberShip);
+    const buildRequestVisibility = createBuildRequestVisibility({ getResourceById, getCatalogConfigProvider });
 
     return parseZodObjectAsync(input, SubmitWorkflowInput)
       .andThen(getCatalogConfig)
       .andThen(getApprovalFlowConfig)
+      // Requester authorization: every input resource with requesterGroupIds must include the requester.
+      .andThen(checkCanSubmit)
       .andThen((parsedInput) => {
         if (parsedInput.autoRevokeDuration) {
           // Check autoRevokeDuration is set but autoRevoke is not enabled
@@ -163,6 +171,10 @@ export const submitWorkflow =
           // Return Internal server error because nothing ApproverType is unexpected.
           return errAsync(new StampHubError("ApproverType is not set", "ApproverType is not set", "INTERNAL_SERVER_ERROR"));
         }
+      })
+      .andThen((extendInput) => {
+        // Snapshot who may view this request (fixed at submit time; not affected by later resource changes).
+        return buildRequestVisibility(extendInput).map((visibility) => ({ ...extendInput, visibility }));
       })
       .andThen((extendInput) => {
         return submitApprovalRequest(extendInput).map((submittedApprovalRequest) => {

--- a/packages/hub/src/workflows/resource/getResourceInfo.test.ts
+++ b/packages/hub/src/workflows/resource/getResourceInfo.test.ts
@@ -2,7 +2,8 @@ import { none, some } from "@stamp-lib/stamp-option";
 import { HandlerError, ResourceHandlers } from "@stamp-lib/stamp-types/catalogInterface/handler";
 import { CatalogConfigProvider } from "@stamp-lib/stamp-types/configInterface";
 import { CatalogConfig, ResourceOnDB, ResourceTypeConfig } from "@stamp-lib/stamp-types/models";
-import { DBError, ResourceDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { CatalogDBProvider, DBError, ResourceDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { GroupMemberShipProvider, IdentityPluginError } from "@stamp-lib/stamp-types/pluginInterface/identity";
 import { err, ok, okAsync } from "neverthrow";
 import { describe, expect, it, vi } from "vitest";
 import { getResourceInfo } from "./getResourceInfo";
@@ -62,6 +63,12 @@ describe("getResourceInfo", () => {
     delete: vi.fn().mockResolvedValue(err(new DBError("DB error"))),
   };
 
+  // The resource is not restricted, so these are never consulted.
+  const getCatalogDBProvider: CatalogDBProvider["getById"] = vi.fn().mockReturnValue(okAsync(none));
+  const listGroupMemberShipByUser: GroupMemberShipProvider["listByUser"] = vi
+    .fn()
+    .mockReturnValue(err(new IdentityPluginError("This is Identity Plugin Error")));
+
   const input: GetResourceInfoInput = {
     catalogId: "test-catalog-id",
     resourceTypeId: "test-resource-type-id",
@@ -93,6 +100,8 @@ describe("getResourceInfo", () => {
     const result = await getResourceInfo({
       getCatalogConfigProvider: catalogConfigProvider.get,
       getResourceDBProvider: resourceDBProviderForSuccess.getById,
+      getCatalogDBProvider,
+      listGroupMemberShipByUser,
     })(input);
     if (result.isErr()) {
       throw result.error;
@@ -122,6 +131,8 @@ describe("getResourceInfo", () => {
     const result = await getResourceInfo({
       getCatalogConfigProvider: catalogConfigProvider.get,
       getResourceDBProvider: resourceDBProviderForSuccess.getById,
+      getCatalogDBProvider,
+      listGroupMemberShipByUser,
     })(input);
     if (result.isOk()) {
       throw result.value;
@@ -148,6 +159,8 @@ describe("getResourceInfo", () => {
     const result = await getResourceInfo({
       getCatalogConfigProvider: catalogConfigProvider.get,
       getResourceDBProvider: resourceDBProviderForSuccess.getById,
+      getCatalogDBProvider,
+      listGroupMemberShipByUser,
     })(input);
     if (result.isOk()) {
       throw result.value;
@@ -156,5 +169,33 @@ describe("getResourceInfo", () => {
     expect(result.error.systemMessage).toBe("ResourceType not found");
     expect(result.error.userMessage).toBe("ResourceType Not Found");
     expect(result.error.code).toBe("NOT_FOUND");
+  });
+  describe("visibility", () => {
+    const catalogConfigProvider: CatalogConfigProvider = {
+      get: () => okAsync(some({ ...baseCatalogConfig, resourceTypes: [resourceTypeConfigForSuccess] })),
+    };
+    const restrictedGetById: ResourceDBProvider["getById"] = vi.fn().mockReturnValue(okAsync(some({ ownerGroupId, visibility: "restricted" })));
+    const membership = (groups: Array<string>) =>
+      vi.fn().mockReturnValue(okAsync({ items: groups.map((groupId) => ({ groupId, userId: requestUserId, role: "member", createdAt: "", updatedAt: "" })) }));
+
+    it("returns FORBIDDEN for a restricted resource when the user is unrelated", async () => {
+      const result = await getResourceInfo({
+        getCatalogConfigProvider: catalogConfigProvider.get,
+        getResourceDBProvider: restrictedGetById,
+        getCatalogDBProvider: vi.fn().mockReturnValue(okAsync(some({ id: "test-catalog-id", ownerGroupId: undefined }))),
+        listGroupMemberShipByUser: membership([]),
+      })(input);
+      expect(result._unsafeUnwrapErr().code).toBe("FORBIDDEN");
+    });
+
+    it("returns the resource to an owner group member", async () => {
+      const result = await getResourceInfo({
+        getCatalogConfigProvider: catalogConfigProvider.get,
+        getResourceDBProvider: restrictedGetById,
+        getCatalogDBProvider: vi.fn().mockReturnValue(okAsync(some({ id: "test-catalog-id", ownerGroupId: undefined }))),
+        listGroupMemberShipByUser: membership([ownerGroupId]),
+      })(input);
+      expect(result._unsafeUnwrap().isSome()).toBe(true);
+    });
   });
 });

--- a/packages/hub/src/workflows/resource/getResourceInfo.ts
+++ b/packages/hub/src/workflows/resource/getResourceInfo.ts
@@ -1,20 +1,27 @@
 import { GetResourceInfoInput } from "./input";
 
-import { Option } from "@stamp-lib/stamp-option";
+import { Option, none, some } from "@stamp-lib/stamp-option";
 import { CatalogConfigProvider } from "@stamp-lib/stamp-types/configInterface";
-import { ResourceInfo } from "@stamp-lib/stamp-types/models";
-import { ResourceDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
-import { ResultAsync } from "neverthrow";
+import { ResourceInfo, ResourceOnDB } from "@stamp-lib/stamp-types/models";
+import { CatalogDBProvider, ResourceDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { GroupMemberShipProvider } from "@stamp-lib/stamp-types/pluginInterface/identity";
+import { ResultAsync, okAsync } from "neverthrow";
 import { convertStampHubError, StampHubError } from "../../error";
 import { createGetCatalogConfig } from "../../events/catalog/catalogConfig";
 import { createValidateCatalogId } from "../../events/catalog/validation";
 import { getResourceTypeConfig } from "../../events/resource-type/resourceTypeConfig";
 import { validateResourceTypeId } from "../../events/resource-type/validation";
 import { createGetResourceInfo } from "../../events/resource/info/get";
+import { createCheckCanViewResource } from "../../events/resource/visibility/canViewResource";
 import { parseZodObjectAsync } from "../../utils/neverthrow";
 
 export type GetResourceInfo = (input: GetResourceInfoInput) => ResultAsync<Option<ResourceInfo>, StampHubError>;
-export const getResourceInfo = (providers: {
+
+/**
+ * Resolve ResourceInfo without the visibility check.
+ * For internal / system use only (e.g. applying an approved resource update); user-facing routes must use `getResourceInfo`.
+ */
+export const getResourceInfoWithoutVisibilityCheck = (providers: {
   getCatalogConfigProvider: CatalogConfigProvider["get"];
   getResourceDBProvider: ResourceDBProvider["getById"];
 }): GetResourceInfo => {
@@ -29,6 +36,55 @@ export const getResourceInfo = (providers: {
       .andThen(validateResourceTypeId)
       .andThen(getResourceTypeConfig)
       .andThen(getResourceInfoEvent)
+      .mapErr(convertStampHubError);
+  };
+};
+
+/**
+ * Resolve ResourceInfo for the request user.
+ * Resources with visibility "restricted" are only returned to catalog owner / owner / approver / requester / parent owner (FORBIDDEN otherwise).
+ */
+export const getResourceInfo = (providers: {
+  getCatalogConfigProvider: CatalogConfigProvider["get"];
+  getResourceDBProvider: ResourceDBProvider["getById"];
+  getCatalogDBProvider: CatalogDBProvider["getById"];
+  listGroupMemberShipByUser: GroupMemberShipProvider["listByUser"];
+}): GetResourceInfo => {
+  const { getCatalogConfigProvider, getResourceDBProvider, getCatalogDBProvider, listGroupMemberShipByUser } = providers;
+  const getResourceInfoInternal = getResourceInfoWithoutVisibilityCheck({ getCatalogConfigProvider, getResourceDBProvider });
+  const checkCanViewResource = createCheckCanViewResource({
+    getResourceDB: getResourceDBProvider,
+    getCatalogDB: getCatalogDBProvider,
+    listGroupMemberShipByUser,
+  });
+  return (input: GetResourceInfoInput): ResultAsync<Option<ResourceInfo>, StampHubError> => {
+    return getResourceInfoInternal(input)
+      .andThen((resourceInfo) => {
+        if (resourceInfo.isNone()) {
+          return okAsync(none);
+        }
+        const info = resourceInfo.value;
+        const resourceOnDB: ResourceOnDB = {
+          id: info.id,
+          catalogId: info.catalogId,
+          resourceTypeId: info.resourceTypeId,
+          approverGroupId: info.approverGroupId,
+          ownerGroupId: info.ownerGroupId,
+          requesterGroupIds: info.requesterGroupIds,
+          visibility: info.visibility,
+        };
+        return checkCanViewResource({
+          requestUserId: input.requestUserId,
+          catalogId: input.catalogId,
+          resourceOnDB: some(resourceOnDB),
+          resolveParent: () =>
+            okAsync(
+              info.parentResourceId !== undefined && info.parentResourceTypeId !== undefined
+                ? some({ resourceTypeId: info.parentResourceTypeId, resourceId: info.parentResourceId })
+                : none
+            ),
+        }).map(() => resourceInfo);
+      })
       .mapErr(convertStampHubError);
   };
 };

--- a/packages/hub/src/workflows/resource/listResourceAuditItem.test.ts
+++ b/packages/hub/src/workflows/resource/listResourceAuditItem.test.ts
@@ -1,5 +1,5 @@
 import { createLogger } from "@stamp-lib/stamp-logger";
-import { some } from "@stamp-lib/stamp-option";
+import { none, some } from "@stamp-lib/stamp-option";
 import { HandlerError, ListResourceAuditItemOutput, ResourceHandlers } from "@stamp-lib/stamp-types/catalogInterface/handler";
 import { CatalogConfig } from "@stamp-lib/stamp-types/models";
 import { err, ok, okAsync } from "neverthrow";
@@ -63,6 +63,17 @@ const testCatalogConfig: CatalogConfig = {
   resourceTypes: [testResourceTypeConfig],
 };
 
+// The resource has no hub-side row, so it is not restricted and no visibility lookups happen.
+const getResourceDBProvider = vi.fn().mockReturnValue(okAsync(none));
+const getCatalogDBProvider = vi.fn().mockReturnValue(okAsync(none));
+const listGroupMemberShipByUser = vi.fn().mockReturnValue(okAsync({ items: [] }));
+const providersWith = (getCatalogConfigProvider: ReturnType<typeof vi.fn>) => ({
+  getCatalogConfigProvider,
+  getResourceDBProvider,
+  getCatalogDBProvider,
+  listGroupMemberShipByUser,
+});
+
 describe("Testing listResourceAuditItem", () => {
   it("should list resource audit item with valid input", async () => {
     const getCatalogConfigSuccess = vi.fn().mockReturnValue(okAsync(some(testCatalogConfig)));
@@ -84,7 +95,7 @@ describe("Testing listResourceAuditItem", () => {
       ],
       paginationToken: undefined,
     };
-    const result = await listResourceAuditItem(logger, getCatalogConfigSuccess)(input);
+    const result = await listResourceAuditItem(logger, providersWith(getCatalogConfigSuccess))(input);
     if (result.isErr()) {
       throw result.error;
     }
@@ -113,7 +124,7 @@ describe("Testing listResourceAuditItem", () => {
       paginationToken: undefined,
       limit: undefined,
     };
-    const result = await listResourceAuditItem(logger, getCatalogConfigError)(input);
+    const result = await listResourceAuditItem(logger, providersWith(getCatalogConfigError))(input);
     expect(result.isErr()).toBe(true);
   });
 
@@ -147,7 +158,7 @@ describe("Testing listResourceAuditItem", () => {
       paginationToken: undefined,
       limit: undefined,
     };
-    const result = await listResourceAuditItem(logger, getCatalogConfig)(input);
+    const result = await listResourceAuditItem(logger, providersWith(getCatalogConfig))(input);
     expect(result.isErr()).toBe(true);
   });
 
@@ -199,7 +210,34 @@ describe("Testing listResourceAuditItem", () => {
     ],
   ])("returns failure result", async (key, input) => {
     const getCatalogConfigSuccess = vi.fn().mockReturnValue(okAsync(some(testCatalogConfig)));
-    const result = await listResourceAuditItem(logger, getCatalogConfigSuccess)(input);
+    const result = await listResourceAuditItem(logger, providersWith(getCatalogConfigSuccess))(input);
     expect(result.isErr()).toBe(true);
+  });
+  describe("visibility", () => {
+    const ownerGroupId = "96fc6a4c-b5d3-8c2b-0307-165168a023cd";
+    const input: ListResourceAuditItemInput = { catalogId, resourceTypeId, resourceId, requestUserId };
+    const restricted = vi.fn().mockReturnValue(okAsync(some({ id: resourceId, catalogId, resourceTypeId, ownerGroupId, visibility: "restricted" })));
+    const membership = (groups: Array<string>) =>
+      vi.fn().mockReturnValue(okAsync({ items: groups.map((groupId) => ({ groupId, userId: requestUserId, role: "member", createdAt: "", updatedAt: "" })) }));
+
+    it("returns FORBIDDEN for a restricted resource when the user is unrelated", async () => {
+      const result = await listResourceAuditItem(logger, {
+        getCatalogConfigProvider: vi.fn().mockReturnValue(okAsync(some(testCatalogConfig))),
+        getResourceDBProvider: restricted,
+        getCatalogDBProvider: vi.fn().mockReturnValue(okAsync(none)),
+        listGroupMemberShipByUser: membership([]),
+      })(input);
+      expect(result._unsafeUnwrapErr().code).toBe("FORBIDDEN");
+    });
+
+    it("lists audit items for an owner group member", async () => {
+      const result = await listResourceAuditItem(logger, {
+        getCatalogConfigProvider: vi.fn().mockReturnValue(okAsync(some(testCatalogConfig))),
+        getResourceDBProvider: restricted,
+        getCatalogDBProvider: vi.fn().mockReturnValue(okAsync(none)),
+        listGroupMemberShipByUser: membership([ownerGroupId]),
+      })(input);
+      expect(result._unsafeUnwrap().auditItems.length).toBe(1);
+    });
   });
 });

--- a/packages/hub/src/workflows/resource/listResourceAuditItem.ts
+++ b/packages/hub/src/workflows/resource/listResourceAuditItem.ts
@@ -1,20 +1,38 @@
 import { Logger } from "@stamp-lib/stamp-logger";
+import { none, some } from "@stamp-lib/stamp-option";
 import { ListResourceAuditItemOutput } from "@stamp-lib/stamp-types/catalogInterface/handler";
 import { CatalogConfigProvider } from "@stamp-lib/stamp-types/configInterface";
 import { ResourceAuditItem } from "@stamp-lib/stamp-types/models";
-import { ResultAsync, errAsync } from "neverthrow";
+import { CatalogDBProvider, ResourceDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { GroupMemberShipProvider } from "@stamp-lib/stamp-types/pluginInterface/identity";
+import { ResultAsync, errAsync, okAsync } from "neverthrow";
 import { StampHubError, convertStampHubError } from "../../error";
 import { createGetCatalogConfig } from "../../events/catalog/catalogConfig";
 import { getResourceTypeConfig } from "../../events/resource-type/resourceTypeConfig";
+import { createCheckCanViewResource } from "../../events/resource/visibility/canViewResource";
 import { convertPromiseResultToResultAsync, parseZodObject } from "../../utils/neverthrow";
 import { ListResourceAuditItemInput } from "./input";
 
 export type ListResourceAuditItemFunc = <T extends ListResourceAuditItemInput>(input: T) => ResultAsync<ListResourceAuditItemOutput, StampHubError>;
 
 export const listResourceAuditItem =
-  (logger: Logger, getCatalogConfigProvider: CatalogConfigProvider["get"]): ListResourceAuditItemFunc =>
+  (
+    logger: Logger,
+    providers: {
+      getCatalogConfigProvider: CatalogConfigProvider["get"];
+      getResourceDBProvider: ResourceDBProvider["getById"];
+      getCatalogDBProvider: CatalogDBProvider["getById"];
+      listGroupMemberShipByUser: GroupMemberShipProvider["listByUser"];
+    }
+  ): ListResourceAuditItemFunc =>
   (input: ListResourceAuditItemInput) => {
+    const { getCatalogConfigProvider, getResourceDBProvider, getCatalogDBProvider, listGroupMemberShipByUser } = providers;
     const getCatalogConfig = createGetCatalogConfig(getCatalogConfigProvider);
+    const checkCanViewResource = createCheckCanViewResource({
+      getResourceDB: getResourceDBProvider,
+      getCatalogDB: getCatalogDBProvider,
+      listGroupMemberShipByUser,
+    });
 
     const parsedInputResult = parseZodObject(input, ListResourceAuditItemInput);
     if (parsedInputResult.isErr()) {
@@ -24,6 +42,33 @@ export const listResourceAuditItem =
 
     return getCatalogConfig(parsedInput)
       .andThen(getResourceTypeConfig)
+      .andThen((extendInput) => {
+        // visibility: "restricted" resources are only visible to catalog owner / owner / approver / requester / parent owner.
+        // The parent is resolved through the catalog handler only when needed.
+        return getResourceDBProvider({ id: extendInput.resourceId, catalogId: extendInput.catalogId, resourceTypeId: extendInput.resourceTypeId })
+          .mapErr(convertStampHubError)
+          .andThen((resourceOnDB) =>
+            checkCanViewResource({
+              requestUserId: extendInput.requestUserId,
+              catalogId: extendInput.catalogId,
+              resourceOnDB,
+              resolveParent: () => {
+                const parentResourceTypeId = extendInput.resourceTypeConfig.parentResourceTypeId;
+                if (parentResourceTypeId === undefined) {
+                  return okAsync(none);
+                }
+                return convertPromiseResultToResultAsync()(
+                  extendInput.resourceTypeConfig.handlers.getResource({ resourceTypeId: extendInput.resourceTypeId, resourceId: extendInput.resourceId })
+                ).map((resource) =>
+                  resource.isSome() && resource.value.parentResourceId !== undefined
+                    ? some({ resourceTypeId: parentResourceTypeId, resourceId: resource.value.parentResourceId })
+                    : none
+                );
+              },
+            })
+          )
+          .map(() => extendInput);
+      })
       .andThen((extendInput) => {
         return convertPromiseResultToResultAsync()(
           extendInput.resourceTypeConfig.handlers.listResourceAuditItem({

--- a/packages/hub/src/workflows/resource/listResourceOutlines.test.ts
+++ b/packages/hub/src/workflows/resource/listResourceOutlines.test.ts
@@ -2,6 +2,9 @@ import { some } from "@stamp-lib/stamp-option";
 import { HandlerError, ResourceHandlers } from "@stamp-lib/stamp-types/catalogInterface/handler";
 import { CatalogConfigProvider } from "@stamp-lib/stamp-types/configInterface";
 import { CatalogConfig, ResourceTypeConfig } from "@stamp-lib/stamp-types/models";
+import { CatalogDBProvider, DBError, ResourceDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { GroupMemberShipProvider, IdentityPluginError } from "@stamp-lib/stamp-types/pluginInterface/identity";
+import { vi } from "vitest";
 import { err, ok, okAsync } from "neverthrow";
 import { describe, expect, it } from "vitest";
 import { ListResourceOutlinesInput } from "./input";
@@ -118,6 +121,28 @@ const testResourceTypeConfig2: ResourceTypeConfig = {
 };
 
 describe("listResourceOutlines", () => {
+  // No resource has hub-side settings, so no visibility filtering happens.
+  const catalogDBProvider: CatalogDBProvider = {
+    getById: vi.fn().mockReturnValue(okAsync(some({ id: "test-catalog-id", ownerGroupId: undefined }))),
+    listAll: vi.fn().mockResolvedValue(err(new DBError("DB error"))),
+    set: vi.fn().mockResolvedValue(err(new DBError("DB error"))),
+    delete: vi.fn().mockResolvedValue(err(new DBError("DB error"))),
+  };
+  const resourceDBProvider: ResourceDBProvider = {
+    getById: vi.fn(),
+    set: vi.fn(),
+    updatePendingUpdateParams: vi.fn(),
+    delete: vi.fn(),
+    createAuditNotification: vi.fn(),
+    updateAuditNotification: vi.fn(),
+    deleteAuditNotification: vi.fn(),
+    listByResourceType: vi.fn().mockReturnValue(okAsync({ items: [] })),
+  };
+  const listGroupMemberShipByUser: GroupMemberShipProvider["listByUser"] = vi
+    .fn()
+    .mockReturnValue(err(new IdentityPluginError("This is Identity Plugin Error")));
+  const baseProviders = { catalogDBProvider, resourceDBProvider, listGroupMemberShipByUser };
+
   const input: ListResourceOutlinesInput = {
     catalogId: "test-catalog-id",
     resourceTypeId: "test-resource-type-id",
@@ -138,7 +163,7 @@ describe("listResourceOutlines", () => {
     const catalogConfigProvider: CatalogConfigProvider = {
       get: getCatalogConfigProvider,
     };
-    const result = await listResourceOutlines({ catalogConfigProvider })(input);
+    const result = await listResourceOutlines({ ...baseProviders, catalogConfigProvider })(input);
     if (result.isErr()) {
       throw result.error;
     }
@@ -172,7 +197,7 @@ describe("listResourceOutlines", () => {
     const catalogConfigProvider: CatalogConfigProvider = {
       get: getCatalogConfigProvider,
     };
-    const result = await listResourceOutlines({ catalogConfigProvider })(input);
+    const result = await listResourceOutlines({ ...baseProviders, catalogConfigProvider })(input);
     if (result.isErr()) {
       throw result.error;
     }
@@ -197,7 +222,55 @@ describe("listResourceOutlines", () => {
     const catalogConfigProvider: CatalogConfigProvider = {
       get: getCatalogConfigProvider,
     };
-    const result = await listResourceOutlines({ catalogConfigProvider })(input);
+    const result = await listResourceOutlines({ ...baseProviders, catalogConfigProvider })(input);
     expect(result.isErr()).toBe(true);
+  });
+  describe("visibility filtering", () => {
+    const ownerGroupId = "96fc6a4c-b5d3-8c2b-0307-165168a023cd";
+    const catalogOwnerGroupId = "0a3d8d5b-7a3f-4b2e-9c1d-2f4e6a8b0c1d";
+    const catalogConfig: CatalogConfig = {
+      id: "test-catalog-id",
+      name: "test Catalog",
+      description: "Contains target ResourceTypeConfig.",
+      approvalFlows: [],
+      resourceTypes: [testResourceTypeConfig],
+    };
+    const catalogConfigProvider: CatalogConfigProvider = { get: () => okAsync(some(catalogConfig)) };
+    const restrictedRow = { id: resourceId, catalogId: "test-catalog-id", resourceTypeId: "test-resource-type-id", ownerGroupId, visibility: "restricted" as const };
+    const providersWith = (memberOf: Array<string>, catalogOwner?: string) => ({
+      catalogConfigProvider,
+      catalogDBProvider: { ...catalogDBProvider, getById: vi.fn().mockReturnValue(okAsync(some({ id: "test-catalog-id", ownerGroupId: catalogOwner }))) },
+      resourceDBProvider: { ...resourceDBProvider, listByResourceType: vi.fn().mockReturnValue(okAsync({ items: [restrictedRow] })) },
+      listGroupMemberShipByUser: vi
+        .fn()
+        .mockReturnValue(okAsync({ items: memberOf.map((groupId) => ({ groupId, userId: requestUserId, role: "member", createdAt: "", updatedAt: "" })) })),
+    });
+
+    it("hides restricted resources from unrelated users but keeps paginationToken", async () => {
+      const providers = providersWith([]);
+      const result = await listResourceOutlines(providers)(input);
+      expect(result._unsafeUnwrap()).toEqual({ items: [], paginationToken });
+      expect(providers.resourceDBProvider.listByResourceType).toHaveBeenCalledTimes(1);
+      expect(providers.listGroupMemberShipByUser).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows restricted resources to owner group members", async () => {
+      const result = await listResourceOutlines(providersWith([ownerGroupId]))(input);
+      expect(result._unsafeUnwrap().items.map((item) => item.id)).toEqual([resourceId]);
+    });
+
+    it("shows restricted resources to the catalog owner", async () => {
+      const result = await listResourceOutlines(providersWith([catalogOwnerGroupId], catalogOwnerGroupId))(input);
+      expect(result._unsafeUnwrap().items.map((item) => item.id)).toEqual([resourceId]);
+    });
+
+    it("does not consult identity or the resource DB when the handler returns no resources", async () => {
+      const emptyCatalogConfig: CatalogConfig = { ...catalogConfig, resourceTypes: [testEmptyResourceTypeConfig] };
+      const providers = { ...providersWith([]), catalogConfigProvider: { get: () => okAsync(some(emptyCatalogConfig)) } };
+      const result = await listResourceOutlines(providers)(input);
+      expect(result._unsafeUnwrap()).toEqual({ items: [], paginationToken: undefined });
+      expect(providers.resourceDBProvider.listByResourceType).not.toHaveBeenCalled();
+      expect(providers.listGroupMemberShipByUser).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/hub/src/workflows/resource/listResourceOutlines.ts
+++ b/packages/hub/src/workflows/resource/listResourceOutlines.ts
@@ -1,24 +1,39 @@
 import { CatalogConfigProvider } from "@stamp-lib/stamp-types/configInterface";
 import { ResourceOutline } from "@stamp-lib/stamp-types/models";
-import { ResultAsync, errAsync } from "neverthrow";
+import { CatalogDBProvider, ResourceDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { GroupMemberShipProvider } from "@stamp-lib/stamp-types/pluginInterface/identity";
+import { ResultAsync, errAsync, okAsync } from "neverthrow";
 import z from "zod";
 import { StampHubError, convertStampHubError } from "../../error";
 import { createGetCatalogConfig } from "../../events/catalog/catalogConfig";
 import { getResourceTypeConfig } from "../../events/resource-type/resourceTypeConfig";
+import { createPrepareResourceVisibilityFilter } from "../../events/resource/visibility/canViewResource";
 import { convertPromiseResultToResultAsync, parseZodObject } from "../../utils/neverthrow";
 import { ListResourceOutlinesInput } from "./input";
 
 export const ListResourceOutlinesOutput = z.object({
+  // Resources the request user is not allowed to see (visibility: "restricted") are filtered out.
+  // A page may therefore contain fewer items than the catalog returned, or even none, while paginationToken is still set.
   items: z.array(ResourceOutline),
   paginationToken: z.string().optional(),
 });
 export type ListResourceOutlinesOutput = z.infer<typeof ListResourceOutlinesOutput>;
 
 export const listResourceOutlines =
-  (providers: { catalogConfigProvider: CatalogConfigProvider }) =>
+  (providers: {
+    catalogConfigProvider: CatalogConfigProvider;
+    catalogDBProvider: CatalogDBProvider;
+    resourceDBProvider: ResourceDBProvider;
+    listGroupMemberShipByUser: GroupMemberShipProvider["listByUser"];
+  }) =>
   (input: ListResourceOutlinesInput): ResultAsync<ListResourceOutlinesOutput, StampHubError> => {
-    const { catalogConfigProvider } = providers;
+    const { catalogConfigProvider, catalogDBProvider, resourceDBProvider, listGroupMemberShipByUser } = providers;
     const getCatalogConfig = createGetCatalogConfig(catalogConfigProvider.get);
+    const prepareVisibilityFilter = createPrepareResourceVisibilityFilter({
+      listResourceByResourceType: resourceDBProvider.listByResourceType,
+      getCatalogDB: catalogDBProvider.getById,
+      listGroupMemberShipByUser,
+    });
 
     const parsedInputResult = parseZodObject(input, ListResourceOutlinesInput);
     if (parsedInputResult.isErr()) {
@@ -36,10 +51,10 @@ export const listResourceOutlines =
             prefix: extendInput.prefix,
             paginationToken: extendInput.paginationToken,
           })
-        );
+        ).map((listResourcesResult) => ({ ...extendInput, listResourcesResult }));
       })
-
-      .map((listResourcesResult) => {
+      .andThen((extendInput) => {
+        const { listResourcesResult, resourceTypeConfig } = extendInput;
         const resourceOutlines: Array<ResourceOutline> = listResourcesResult.resources.map((resource) => {
           return {
             id: resource.resourceId,
@@ -50,7 +65,19 @@ export const listResourceOutlines =
             parentResourceId: resource.parentResourceId,
           };
         });
-        return { items: resourceOutlines, paginationToken: listResourcesResult.paginationToken };
+        if (resourceOutlines.length === 0) {
+          return okAsync({ items: resourceOutlines, paginationToken: listResourcesResult.paginationToken });
+        }
+        // Hide resources with visibility "restricted" from users who are not catalog owner / owner / approver / requester / parent owner.
+        return prepareVisibilityFilter({
+          requestUserId: parsedInput.requestUserId,
+          catalogId: parsedInput.catalogId,
+          resourceTypeId: parsedInput.resourceTypeId,
+          parentResourceTypeId: resourceTypeConfig.parentResourceTypeId,
+        }).map((isVisible) => ({
+          items: resourceOutlines.filter((outline) => isVisible({ id: outline.id, parentResourceId: outline.parentResourceId })),
+          paginationToken: listResourcesResult.paginationToken,
+        }));
       })
       .mapErr(convertStampHubError);
   };

--- a/packages/hub/src/workflows/resource/updateResourceParamsWithApproval/index.ts
+++ b/packages/hub/src/workflows/resource/updateResourceParamsWithApproval/index.ts
@@ -5,7 +5,7 @@ import { UpdateResourceParamsWithApprovalInput } from "../input";
 import { CatalogConfigProvider } from "@stamp-lib/stamp-types/configInterface";
 import { ResourceDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
 import { Logger } from "@stamp-lib/stamp-logger";
-import { getResourceInfo, GetResourceInfo } from "../getResourceInfo";
+import { getResourceInfoWithoutVisibilityCheck, GetResourceInfo } from "../getResourceInfo";
 import { createResolveResourceWithFallback, createResolveApproverGroup, createResolveSystemCatalog } from "./resolution";
 import { createExecuteApprovalWorkflow, SubmitWorkflowForResourceUpdate } from "./execution";
 import { createGetCatalogConfig } from "../../../events/catalog/catalogConfig";
@@ -38,7 +38,7 @@ export const createWorkflowDependencies = (providers: {
   const getResourceTypeInfoFunc = getResourceTypeInfo(getCatalogConfig);
 
   // Create base resource info function
-  const getResourceInfoFunc: GetResourceInfo = getResourceInfo({
+  const getResourceInfoFunc: GetResourceInfo = getResourceInfoWithoutVisibilityCheck({
     getCatalogConfigProvider: catalogConfigProvider.get,
     getResourceDBProvider: resourceDBProvider.getById,
   });


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### 🎉 Reason for this change

Stack **2/4** of the "resource requester groups + visibility" feature (see #102 for the motivation). This PR makes the settings introduced in #102 actually take effect in the hub.

### 🔀 Description of changes

| Action | Before | After |
| --- | --- | --- |
| `approvalRequest.submit` | anyone | FORBIDDEN unless the requester is in `requesterGroupIds` of every input resource that has it set (no owner / approver bypass; visibility is not consulted) |
| `approvalRequest.approve` | — | BAD_REQUEST "Requester is no longer allowed to request this resource" if the requester was removed from `requesterGroupIds` after submitting (the approver can still reject) |
| `resource.listOutlines` | all resources | `visibility: "restricted"` resources are hidden unless the caller is catalog owner / owner / approver / requester group member / parent resource owner. `paginationToken` is passed through, so a page may contain fewer (or zero) items and still carry a token |
| `resource.get`, `resource.listAuditItem` | anyone | FORBIDDEN for restricted resources under the same rule |
| stored approval request | — | gets a `visibility` snapshot at submit time: `{ type: "restricted", viewerGroupIds }` = union of owner / approver / requester / parent-owner groups of restricted input resources (including the target of `stamp-system/resource-update` requests, recovered from `inputParams`). Consumed by #105 |

Unrestricted resources (no `visibility` set) behave exactly as before, and every check short-circuits before any identity / catalog lookup.

Design decisions

- **Constant number of reads for lists**: `listOutlines` loads the type's hub rows with one `listByResourceType` query (+1 for the parent type), builds the viewer's group set once (`listByUser`), checks catalog ownership once, then filters synchronously. If no row is restricted, or the caller is the catalog owner, nothing else is read.
- `isResourceVisibleTo` is a pure function shared by the single-resource check (`createCheckCanViewResource`) and the list filter (`createPrepareResourceVisibilityFilter`). The parent-owner rule is evaluated last and resolves the parent only when every cheaper rule failed (`listAuditItem` resolves it through the catalog handler).
- Requester authorization looks at `inputResources` only, so `stamp-system/resource-update` requests (`inputResources: []`) are unaffected — parameter updates are already guarded by `canEditResource`. Their visibility snapshot still covers the target resource.
- Internal / system callers (`resource-update` flow, `updateResourceParamsWithApproval`) use `getResourceInfoWithoutVisibilityCheck`.

### 🖨️ Description of how you validated changes

- New unit tests: `events/approval-request/authz/submit.test.ts`, `events/approval-request/resources.test.ts`, `events/approval-request/visibility/buildRequestVisibility.test.ts`, `events/resource/requester/isRequesterOfResource.test.ts`, `events/resource/info/listAllResourceOnDBByType.test.ts`, `events/resource/visibility/canViewResource.test.ts`.
- Extended: `membership.test.ts`, `listResourceOutlines.test.ts`, `getResourceInfo.test.ts`, `listResourceAuditItem.test.ts`, `submit.test.ts` (FORBIDDEN, snapshot, client-supplied visibility ignored), `approve.test.ts` (re-check).
- `packages/hub`: 574 tests pass; `npm run lint` clean.

### 🔗 Related links

- Stack: #102 → #103 (this) → #105 → #106
