### PR TITLE
feat(hub): hide approval requests for restricted resources from non-stakeholders (stack 3/4)

### DIFF
--- a/docs/user-guide/role.md
+++ b/docs/user-guide/role.md
@@ -21,3 +21,11 @@ Approvers for each Resource. If the Approver type of the Approval Flow in the St
 ### ApprovalFlow Approver
 
 Approvers for each Approval Flow. If the Approver type of the Approval Flow in the Stamp Catalog is specified as ApprovalFlow, they can be set. Instead of directly assigning users as Approvers, user groups are assigned, and users are managed by adding them to the group.
+
+### Resource Requester
+
+Optional per-resource setting. If one or more user groups are assigned as Requester groups of a Resource, only members of those groups can submit Approval Requests that include the Resource. If no group is assigned, anyone can request (default). Catalog Owners, Resource Owners and Parent Resource Owners can assign Requester groups. The check is repeated when a request is approved, so a request from a user who has since been removed from the groups cannot be approved.
+
+### Resource Visibility
+
+Optional per-resource setting, independent of Requester groups. A Resource with visibility `restricted` is only visible to the Catalog Owner, the Resource Owner, the Resource Approver, members of its Requester groups and the Owner of its parent Resource; everyone else does not see it in resource lists, cannot open it and cannot view its audit items. Approval Requests that include a restricted Resource are likewise only visible to the requester, the approver group, the Catalog Owner and those groups (as they were when the request was submitted). The default visibility is `all`.

--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -24,9 +24,26 @@
 | Assign Resource Owner             |             | Possible for all resources | Possible only for child resources of the owner resource  |
 | Assign Resource Approver          |             | Possible for all resources | Possible only for child resources of the owner resource  |
 | Assign ApprovalFlow Approver      |             | ○                          |                                                          |                                                          |
+| Assign Resource Requester Groups  |             | Possible for all resources | Possible only for owner resource and its child resources |                                                          |                                                              |
+| Set Resource Visibility           |             | Possible for all resources | Possible only for owner resource and its child resources |                                                          |                                                              |
 | Create a resource                 |             | Possible for all resources | Possible only for child resources of the owner resource  |
 | Create a anyOneCanCreate resource | ○           | ○                          | ○                                                        | ○                                                        | ○                                                            | ○            |
 | Delete a resource                 |             | Possible for all resources | Possible only for owner resource and its child resources |                                                          |                                                              |
 | Approve Approval Request          |             |                            |                                                          | Possible only for Approval Requests of assigned resource | Possible only for Approval Requests of assigned ApprovalFlow |
 
-- All users can apply for an Approval Request
+- All users can apply for an Approval Request, unless a resource in `inputResources` has `requesterGroupIds` set. In that case only members of at least one of those groups can submit (Catalog Owner / Resource Owner / Approver get no bypass). The membership is re-checked when the request is approved; approving a request whose requester is no longer allowed fails, and the approver can reject it instead.
+
+### Resource access settings
+
+Each resource has two optional, independent settings (set through `resource.updateRequesterGroups` / `resource.updateVisibility`, or on `resource.create`):
+
+| Setting | Default | Effect |
+| --- | --- | --- |
+| `requesterGroupIds` (up to 10 groups) | anyone can request | Only members of one of the groups can submit an Approval Request that includes the resource (`approvalRequest.submit` returns FORBIDDEN). Re-checked on `approve`. |
+| `visibility` (`all` \| `restricted`) | `all` | `restricted` hides the resource from users who are not Catalog Owner, Resource Owner, Resource Approver, a member of `requesterGroupIds`, or Owner of the parent resource: `resource.listOutlines` omits it and `resource.get` / `resource.listAuditItem` return FORBIDDEN. |
+
+Notes:
+
+- Settings are per resource and are not inherited by child resources.
+- When an Approval Request is submitted, the hub stores a visibility snapshot on the request (`visibility: { type: "restricted", viewerGroupIds }`) if any input resource — or the target of a `stamp-system/resource-update` request — is `restricted`. `viewerGroupIds` is the union of the owner / approver / requester / parent-owner groups of those resources at submit time. `approvalRequest.get` and `approvalRequest.listByApprovalFlowId` show such a request only to the requester, members of the request's approver group, the Catalog Owner, and members of `viewerGroupIds`. The snapshot is fixed at submit time, so later changes to or deletion of the resource do not change who can see the request; requests submitted while the resource was `all` stay visible.
+- `listOutlines` / `listByApprovalFlowId` filter each page after reading it, so a page may contain fewer items than the page size while `paginationToken` is still returned. Clients must keep following the token.

--- a/packages/hub/src/events/approval-request/visibility/canViewApprovalRequest.test.ts
+++ b/packages/hub/src/events/approval-request/visibility/canViewApprovalRequest.test.ts
@@ -1,0 +1,92 @@
+import { some } from "@stamp-lib/stamp-option";
+import { okAsync } from "neverthrow";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createCheckCanViewApprovalRequest, createFilterVisibleApprovalRequests, isApprovalRequestVisibleTo } from "./canViewApprovalRequest";
+
+const requester = "dbf33b00-8a5f-e045-4aa1-2d943cb659b6";
+const viewerId = "47f29c51-204c-09f6-2069-f3df073568c7";
+const approverGroupId = "18578bed-c45d-4f67-b9f7-10daf4c85f3f";
+const catalogOwnerGroupId = "0a3d8d5b-7a3f-4b2e-9c1d-2f4e6a8b0c1d";
+const viewerGroupId = "1f10d463-a2fe-c407-2b95-05b561346c8b";
+const unrelatedGroupId = "7c2b9e4d-1a3f-4c5e-9b8a-6d5c4b3a2f1e";
+const catalogId = "test-catalog-id";
+
+const openRequest = { catalogId, requestUserId: requester, approverType: "group" as const, approverId: approverGroupId, visibility: undefined };
+const restrictedRequest = { ...openRequest, visibility: { type: "restricted" as const, viewerGroupIds: [viewerGroupId] } };
+const viewer = (groups: Array<string>, isCatalogOwner = false) => ({ userGroupIds: new Set(groups), isCatalogOwner });
+
+describe("isApprovalRequestVisibleTo", () => {
+  it("is visible to everyone without a snapshot", () => {
+    expect(isApprovalRequestVisibleTo({ request: openRequest, requestUserId: viewerId, viewer: viewer([]) })).toBe(true);
+  });
+  it.each([
+    ["the requester", requester, viewer([])],
+    ["an approver group member", viewerId, viewer([approverGroupId])],
+    ["the catalog owner", viewerId, viewer([], true)],
+    ["a viewer group member", viewerId, viewer([viewerGroupId])],
+  ])("restricted request is visible to %s", (_label, userId, v) => {
+    expect(isApprovalRequestVisibleTo({ request: restrictedRequest, requestUserId: userId, viewer: v })).toBe(true);
+  });
+  it("restricted request is hidden from unrelated users", () => {
+    expect(isApprovalRequestVisibleTo({ request: restrictedRequest, requestUserId: viewerId, viewer: viewer([unrelatedGroupId]) })).toBe(false);
+  });
+});
+
+const membershipOf = (groups: Array<string>) =>
+  vi.fn().mockReturnValue(okAsync({ items: groups.map((groupId) => ({ groupId, userId: viewerId, role: "member", createdAt: "", updatedAt: "" })) }));
+const getCatalogDB = vi.fn().mockReturnValue(okAsync(some({ id: catalogId, ownerGroupId: catalogOwnerGroupId })));
+
+describe("createCheckCanViewApprovalRequest", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("passes requests without a snapshot, and the requester's own requests, without lookups", async () => {
+    const listByUser = membershipOf([]);
+    const check = createCheckCanViewApprovalRequest({ getCatalogDB, listGroupMemberShipByUser: listByUser });
+    expect((await check({ request: openRequest, requestUserId: viewerId })).isOk()).toBe(true);
+    expect((await check({ request: restrictedRequest, requestUserId: requester })).isOk()).toBe(true);
+    expect(listByUser).not.toHaveBeenCalled();
+    expect(getCatalogDB).not.toHaveBeenCalled();
+  });
+
+  it("passes approver / catalog owner / viewer group members and returns the request", async () => {
+    for (const groups of [[approverGroupId], [catalogOwnerGroupId], [viewerGroupId]]) {
+      const check = createCheckCanViewApprovalRequest({ getCatalogDB, listGroupMemberShipByUser: membershipOf(groups) });
+      const result = await check({ request: restrictedRequest, requestUserId: viewerId });
+      expect(result._unsafeUnwrap()).toBe(restrictedRequest);
+    }
+  });
+
+  it("returns FORBIDDEN for unrelated users", async () => {
+    const check = createCheckCanViewApprovalRequest({ getCatalogDB, listGroupMemberShipByUser: membershipOf([unrelatedGroupId]) });
+    const result = await check({ request: restrictedRequest, requestUserId: viewerId });
+    expect(result._unsafeUnwrapErr().code).toBe("FORBIDDEN");
+  });
+});
+
+describe("createFilterVisibleApprovalRequests", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns everything without lookups when no request needs a check", async () => {
+    const listByUser = membershipOf([]);
+    const filter = createFilterVisibleApprovalRequests({ getCatalogDB, listGroupMemberShipByUser: listByUser });
+    const own = { ...restrictedRequest };
+    const result = await filter({ requests: [openRequest, own], requestUserId: requester, catalogId });
+    expect(result._unsafeUnwrap()).toEqual([openRequest, own]);
+    expect(listByUser).not.toHaveBeenCalled();
+  });
+
+  it("filters restricted requests for unrelated users with a single identity lookup", async () => {
+    const listByUser = membershipOf([unrelatedGroupId]);
+    const filter = createFilterVisibleApprovalRequests({ getCatalogDB, listGroupMemberShipByUser: listByUser });
+    const result = await filter({ requests: [openRequest, restrictedRequest, restrictedRequest], requestUserId: viewerId, catalogId });
+    expect(result._unsafeUnwrap()).toEqual([openRequest]);
+    expect(listByUser).toHaveBeenCalledTimes(1);
+    expect(getCatalogDB).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps restricted requests for viewer group members", async () => {
+    const filter = createFilterVisibleApprovalRequests({ getCatalogDB, listGroupMemberShipByUser: membershipOf([viewerGroupId]) });
+    const result = await filter({ requests: [restrictedRequest], requestUserId: viewerId, catalogId });
+    expect(result._unsafeUnwrap()).toEqual([restrictedRequest]);
+  });
+});

--- a/packages/hub/src/events/approval-request/visibility/canViewApprovalRequest.ts
+++ b/packages/hub/src/events/approval-request/visibility/canViewApprovalRequest.ts
@@ -1,0 +1,96 @@
+import { ApprovalRequest } from "@stamp-lib/stamp-types/models";
+import { CatalogDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { GroupId, GroupMemberShipProvider, UserId } from "@stamp-lib/stamp-types/pluginInterface/identity";
+import { ResultAsync, errAsync, okAsync } from "neverthrow";
+import { StampHubError } from "../../../error";
+import { createIsCatalogOwner } from "../../catalog/ownership/isCatalogOwner";
+import { createIsUserInGroupFromSet, createListAllGroupIdsByUser } from "../../group/membership";
+
+export type ApprovalRequestViewer = {
+  /** Every group id the viewer belongs to. */
+  userGroupIds: ReadonlySet<GroupId>;
+  /** Whether the viewer owns the catalog the request belongs to. */
+  isCatalogOwner: boolean;
+};
+
+export type ApprovalRequestForVisibility = Pick<ApprovalRequest, "requestUserId" | "approverType" | "approverId" | "visibility">;
+
+/**
+ * Pure visibility rule for approval requests.
+ * A request without a visibility snapshot is visible to everyone.
+ * A request with `visibility.type === "restricted"` is visible to the requester, members of the approver group,
+ * the catalog owner, and members of any group in the snapshot's `viewerGroupIds`.
+ * The snapshot is fixed at submit time, so later resource changes / deletion do not affect it.
+ */
+export function isApprovalRequestVisibleTo(input: { request: ApprovalRequestForVisibility; requestUserId: UserId; viewer: ApprovalRequestViewer }): boolean {
+  const { request, requestUserId, viewer } = input;
+  if (request.visibility === undefined) {
+    return true;
+  }
+  if (request.requestUserId === requestUserId) {
+    return true;
+  }
+  if (request.approverType === "group" && viewer.userGroupIds.has(request.approverId)) {
+    return true;
+  }
+  if (viewer.isCatalogOwner) {
+    return true;
+  }
+  return request.visibility.viewerGroupIds.some((groupId) => viewer.userGroupIds.has(groupId));
+}
+
+export type ApprovalRequestVisibilityDeps = {
+  getCatalogDB: CatalogDBProvider["getById"];
+  listGroupMemberShipByUser: GroupMemberShipProvider["listByUser"];
+};
+
+/**
+ * Resolve the viewer's group set and catalog ownership with a constant number of lookups.
+ */
+export function createResolveApprovalRequestViewer(deps: ApprovalRequestVisibilityDeps) {
+  const listAllGroupIdsByUser = createListAllGroupIdsByUser(deps.listGroupMemberShipByUser);
+  return (input: { requestUserId: UserId; catalogId: string }): ResultAsync<ApprovalRequestViewer, StampHubError> =>
+    listAllGroupIdsByUser(input.requestUserId).andThen((userGroupIds) =>
+      createIsCatalogOwner(deps.getCatalogDB, createIsUserInGroupFromSet(userGroupIds))(input).map((isCatalogOwner) => ({ userGroupIds, isCatalogOwner }))
+    );
+}
+
+export type CheckCanViewApprovalRequest = <T extends ApprovalRequestForVisibility & { catalogId: string }>(input: {
+  request: T;
+  requestUserId: UserId;
+}) => ResultAsync<T, StampHubError>;
+
+/**
+ * Single-request visibility check (approvalRequest.get). Returns FORBIDDEN when not visible.
+ * Requests without a snapshot short-circuit without any identity / catalog lookup.
+ */
+export function createCheckCanViewApprovalRequest(deps: ApprovalRequestVisibilityDeps): CheckCanViewApprovalRequest {
+  const resolveViewer = createResolveApprovalRequestViewer(deps);
+  return ({ request, requestUserId }) => {
+    if (request.visibility === undefined || request.requestUserId === requestUserId) {
+      return okAsync(request);
+    }
+    return resolveViewer({ requestUserId, catalogId: request.catalogId }).andThen((viewer) => {
+      if (isApprovalRequestVisibleTo({ request, requestUserId, viewer })) {
+        return okAsync(request);
+      }
+      return errAsync(new StampHubError("Permission denied", "Permission Denied", "FORBIDDEN"));
+    });
+  };
+}
+
+/**
+ * Filter a page of approval requests of one catalog for the viewer.
+ * Identity / catalog lookups happen once per page and only if some request carries a visibility snapshot.
+ */
+export function createFilterVisibleApprovalRequests(deps: ApprovalRequestVisibilityDeps) {
+  const resolveViewer = createResolveApprovalRequestViewer(deps);
+  return <T extends ApprovalRequestForVisibility>(input: { requests: Array<T>; requestUserId: UserId; catalogId: string }): ResultAsync<Array<T>, StampHubError> => {
+    const { requests, requestUserId, catalogId } = input;
+    const needsCheck = requests.some((request) => request.visibility !== undefined && request.requestUserId !== requestUserId);
+    if (!needsCheck) {
+      return okAsync(requests);
+    }
+    return resolveViewer({ requestUserId, catalogId }).map((viewer) => requests.filter((request) => isApprovalRequestVisibleTo({ request, requestUserId, viewer })));
+  };
+}

--- a/packages/hub/src/route/userRequest/approvalRequest.ts
+++ b/packages/hub/src/route/userRequest/approvalRequest.ts
@@ -77,9 +77,10 @@ export const approvalRequestRouter = router({
   }),
   listByApprovalFlowId: publicProcedure.input(ListByApprovalFlowId).query(async ({ input, ctx }) => {
     const logger = createStampHubLogger();
-    const listByApprovalFlowIdResult = await listByApprovalFlowIdWorkflow(input, ctx.config.catalogConfig.get, ctx.db.approvalRequestDB).mapErr(
-      convertTRPCError(logger)
-    );
+    const listByApprovalFlowIdResult = await listByApprovalFlowIdWorkflow(input, ctx.config.catalogConfig.get, ctx.db.approvalRequestDB, {
+      getCatalogDBProvider: ctx.db.catalogDB.getById,
+      listGroupMemberShipByUser: ctx.identity.groupMemberShip.listByUser,
+    }).mapErr(convertTRPCError(logger));
     return unwrapOrthrowTRPCError(listByApprovalFlowIdResult);
   }),
   listByRequestUserId: publicProcedure.input(ListByRequestUserIdInput).query(async ({ input, ctx }) => {
@@ -93,7 +94,10 @@ export const approvalRequestRouter = router({
   }),
   get: publicProcedure.input(GetApprovalRequestInput).query(async ({ input, ctx }) => {
     const logger = createStampHubLogger();
-    const getApprovalRequestResult = await GetApprovalRequestWorkflow(input, ctx.db.approvalRequestDB)
+    const getApprovalRequestResult = await GetApprovalRequestWorkflow(input, ctx.db.approvalRequestDB, {
+      getCatalogDBProvider: ctx.db.catalogDB.getById,
+      listGroupMemberShipByUser: ctx.identity.groupMemberShip.listByUser,
+    })
       .andThen(unwrapOptionOrThrowNotFound)
       .mapErr(convertTRPCError(logger));
     return unwrapOrthrowTRPCError(getApprovalRequestResult);

--- a/packages/hub/src/workflows/approval-request/get.test.ts
+++ b/packages/hub/src/workflows/approval-request/get.test.ts
@@ -1,0 +1,71 @@
+import { none, some } from "@stamp-lib/stamp-option";
+import { ApprovalRequestDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { okAsync } from "neverthrow";
+import { describe, expect, it, vi } from "vitest";
+import { GetApprovalRequestWorkflow } from "./get";
+
+const requester = "dbf33b00-8a5f-e045-4aa1-2d943cb659b6";
+const viewerId = "47f29c51-204c-09f6-2069-f3df073568c7";
+const viewerGroupId = "1f10d463-a2fe-c407-2b95-05b561346c8b";
+const approverGroupId = "18578bed-c45d-4f67-b9f7-10daf4c85f3f";
+
+const baseRequest = {
+  requestId: "38296685-5f00-ca43-5e7a-218e9eb7b423",
+  status: "pending",
+  catalogId: "test-catalog-id",
+  approvalFlowId: "test-approval-flow-id",
+  inputParams: [],
+  inputResources: [],
+  requestUserId: requester,
+  approverType: "group",
+  approverId: approverGroupId,
+  requestDate: "2024-01-01T00:00:00.000Z",
+  requestComment: "c",
+  validatedDate: "2024-01-01T00:00:00.000Z",
+  validationHandlerResult: { isSuccess: true, message: "ok" },
+};
+const restrictedRequest = { ...baseRequest, visibility: { type: "restricted", viewerGroupIds: [viewerGroupId] } };
+
+const dbWith = (request: unknown | undefined) =>
+  ({ getById: vi.fn().mockReturnValue(okAsync(request === undefined ? none : some(request))) }) as unknown as ApprovalRequestDBProvider;
+const providersWith = (groups: Array<string>) => ({
+  getCatalogDBProvider: vi.fn().mockReturnValue(okAsync(none)),
+  listGroupMemberShipByUser: vi
+    .fn()
+    .mockReturnValue(okAsync({ items: groups.map((groupId) => ({ groupId, userId: viewerId, role: "member", createdAt: "", updatedAt: "" })) })),
+});
+
+describe("GetApprovalRequestWorkflow", () => {
+  it("returns none when the request does not exist", async () => {
+    const result = await GetApprovalRequestWorkflow({ approvalRequestId: "x", requestUserId: viewerId }, dbWith(undefined), providersWith([]));
+    expect(result._unsafeUnwrap().isNone()).toBe(true);
+  });
+
+  it("returns a request without a snapshot to anyone without identity lookups", async () => {
+    const providers = providersWith([]);
+    const result = await GetApprovalRequestWorkflow({ approvalRequestId: baseRequest.requestId, requestUserId: viewerId }, dbWith(baseRequest), providers);
+    expect(result._unsafeUnwrap().isSome()).toBe(true);
+    expect(providers.listGroupMemberShipByUser).not.toHaveBeenCalled();
+  });
+
+  it("returns a restricted request to the requester and to viewer / approver group members", async () => {
+    for (const [userId, groups] of [
+      [requester, []],
+      [viewerId, [viewerGroupId]],
+      [viewerId, [approverGroupId]],
+    ] as Array<[string, Array<string>]>) {
+      const result = await GetApprovalRequestWorkflow({ approvalRequestId: baseRequest.requestId, requestUserId: userId }, dbWith(restrictedRequest), providersWith(groups));
+      expect(result._unsafeUnwrap().isSome()).toBe(true);
+    }
+  });
+
+  it("returns FORBIDDEN for unrelated users", async () => {
+    const result = await GetApprovalRequestWorkflow({ approvalRequestId: baseRequest.requestId, requestUserId: viewerId }, dbWith(restrictedRequest), providersWith([]));
+    expect(result._unsafeUnwrapErr().code).toBe("FORBIDDEN");
+  });
+
+  it("rejects an invalid requestUserId", async () => {
+    const result = await GetApprovalRequestWorkflow({ approvalRequestId: baseRequest.requestId, requestUserId: "nope" }, dbWith(baseRequest), providersWith([]));
+    expect(result._unsafeUnwrapErr().code).toBe("BAD_REQUEST");
+  });
+});

--- a/packages/hub/src/workflows/approval-request/get.ts
+++ b/packages/hub/src/workflows/approval-request/get.ts
@@ -1,27 +1,45 @@
 import { StampHubError, convertStampHubError } from "../../error";
-import { ApprovalRequestDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { ApprovalRequestDBProvider, CatalogDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
 import { z } from "zod";
 import { parseZodObjectAsync } from "../../utils/neverthrow";
-import { ResultAsync } from "neverthrow";
-import { UserId } from "@stamp-lib/stamp-types/pluginInterface/identity";
+import { ResultAsync, okAsync } from "neverthrow";
+import { GroupMemberShipProvider, UserId } from "@stamp-lib/stamp-types/pluginInterface/identity";
 
 import { ApprovalRequest } from "@stamp-lib/stamp-types/models";
 
-import { Option } from "@stamp-lib/stamp-option";
+import { Option, none, some } from "@stamp-lib/stamp-option";
+import { createCheckCanViewApprovalRequest } from "../../events/approval-request/visibility/canViewApprovalRequest";
 export const GetApprovalRequestInput = z.object({
   approvalRequestId: z.string(),
   requestUserId: UserId,
 });
 export type GetApprovalRequestInput = z.infer<typeof GetApprovalRequestInput>;
 
+/**
+ * Get an approval request for the request user.
+ * Requests that carry a visibility snapshot (restricted resources) are only returned to the requester,
+ * the approver group, the catalog owner and the snapshot's viewer groups; FORBIDDEN otherwise.
+ */
 export function GetApprovalRequestWorkflow(
   input: GetApprovalRequestInput,
-
-  approvalRequestDBProvider: ApprovalRequestDBProvider
+  approvalRequestDBProvider: ApprovalRequestDBProvider,
+  providers: {
+    getCatalogDBProvider: CatalogDBProvider["getById"];
+    listGroupMemberShipByUser: GroupMemberShipProvider["listByUser"];
+  }
 ): ResultAsync<Option<ApprovalRequest>, StampHubError> {
+  const checkCanViewApprovalRequest = createCheckCanViewApprovalRequest({
+    getCatalogDB: providers.getCatalogDBProvider,
+    listGroupMemberShipByUser: providers.listGroupMemberShipByUser,
+  });
   return parseZodObjectAsync(input, GetApprovalRequestInput)
     .andThen((parsedInput) => {
-      return approvalRequestDBProvider.getById(parsedInput.approvalRequestId);
+      return approvalRequestDBProvider.getById(parsedInput.approvalRequestId).andThen((approvalRequest) => {
+        if (approvalRequest.isNone()) {
+          return okAsync(none);
+        }
+        return checkCanViewApprovalRequest({ request: approvalRequest.value, requestUserId: parsedInput.requestUserId }).map((request) => some(request));
+      });
     })
     .mapErr(convertStampHubError);
 }

--- a/packages/hub/src/workflows/approval-request/list.test.ts
+++ b/packages/hub/src/workflows/approval-request/list.test.ts
@@ -1,7 +1,9 @@
 import { expect, it, describe, vi } from "vitest";
 import { okAsync, errAsync } from "neverthrow";
+import { none, some } from "@stamp-lib/stamp-option";
+import { ApprovalRequestDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
 import { StampHubError } from "../../error";
-import { listByRequestUserIdWorkflow, ListByRequestUserIdInput } from "./list";
+import { listByRequestUserIdWorkflow, ListByRequestUserIdInput, listByApprovalFlowIdWorkflow, ListByApprovalFlowId } from "./list";
 
 describe("listByRequestUserIdWorkflow", () => {
   const userId = "80ad2471-1326-a98e-ea2f-fc8146d09019";
@@ -78,5 +80,59 @@ describe("listByRequestUserIdWorkflow", () => {
     expect(listByRequestUserIdSuccess.mock.calls.length).toBe(0);
     expect(validateRequestUserIdError.mock.calls.length).toBe(0);
     expect(listByRequestUserIdResult.isOk()).toBe(false);
+  });
+});
+
+describe("listByApprovalFlowIdWorkflow", () => {
+  const requester = "dbf33b00-8a5f-e045-4aa1-2d943cb659b6";
+  const viewerId = "47f29c51-204c-09f6-2069-f3df073568c7";
+  const viewerGroupId = "1f10d463-a2fe-c407-2b95-05b561346c8b";
+  const catalogId = "test-catalog-id";
+  const approvalFlowId = "test-approval-flow-id";
+  const getCatalogConfigProvider = vi.fn().mockReturnValue(
+    okAsync(
+      some({
+        id: catalogId,
+        name: "c",
+        description: "c",
+        approvalFlows: [{ id: approvalFlowId, name: "f", description: "f", inputParams: [], inputResources: [], approver: { approverType: "approvalFlow" }, handlers: {} }],
+        resourceTypes: [],
+      })
+    )
+  );
+  const openRequest = { requestId: "1", catalogId, approvalFlowId, requestUserId: requester, approverType: "group", approverId: "18578bed-c45d-4f67-b9f7-10daf4c85f3f", status: "pending" };
+  const restrictedRequest = { ...openRequest, requestId: "2", visibility: { type: "restricted", viewerGroupIds: [viewerGroupId] } };
+  const dbWith = (items: Array<unknown>, paginationToken?: string) =>
+    ({ listByApprovalFlowId: vi.fn().mockReturnValue(okAsync({ items, paginationToken })) }) as unknown as ApprovalRequestDBProvider;
+  const providersWith = (groups: Array<string>) => ({
+    getCatalogDBProvider: vi.fn().mockReturnValue(okAsync(none)),
+    listGroupMemberShipByUser: vi
+      .fn()
+      .mockReturnValue(okAsync({ items: groups.map((groupId) => ({ groupId, userId: viewerId, role: "member", createdAt: "", updatedAt: "" })) })),
+  });
+  const input: ListByApprovalFlowId = { catalogId, approvalFlowId, requestUserId: viewerId };
+
+  it("hides restricted requests from unrelated users while keeping paginationToken", async () => {
+    const providers = providersWith([]);
+    const result = await listByApprovalFlowIdWorkflow(input, getCatalogConfigProvider, dbWith([openRequest, restrictedRequest], "next"), providers);
+    expect(result._unsafeUnwrap()).toEqual({ items: [openRequest], paginationToken: "next" });
+    expect(providers.listGroupMemberShipByUser).toHaveBeenCalledTimes(1);
+    expect(providers.getCatalogDBProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows restricted requests to viewer group members and to the requester", async () => {
+    const asMember = await listByApprovalFlowIdWorkflow(input, getCatalogConfigProvider, dbWith([openRequest, restrictedRequest]), providersWith([viewerGroupId]));
+    expect(asMember._unsafeUnwrap().items.map((r) => r.requestId)).toEqual(["1", "2"]);
+    const providers = providersWith([]);
+    const asRequester = await listByApprovalFlowIdWorkflow({ ...input, requestUserId: requester }, getCatalogConfigProvider, dbWith([openRequest, restrictedRequest]), providers);
+    expect(asRequester._unsafeUnwrap().items.map((r) => r.requestId)).toEqual(["1", "2"]);
+    expect(providers.listGroupMemberShipByUser).not.toHaveBeenCalled();
+  });
+
+  it("does no identity lookup when no request has a snapshot", async () => {
+    const providers = providersWith([]);
+    const result = await listByApprovalFlowIdWorkflow(input, getCatalogConfigProvider, dbWith([openRequest]), providers);
+    expect(result._unsafeUnwrap().items.length).toBe(1);
+    expect(providers.listGroupMemberShipByUser).not.toHaveBeenCalled();
   });
 });

--- a/packages/hub/src/workflows/approval-request/list.ts
+++ b/packages/hub/src/workflows/approval-request/list.ts
@@ -1,5 +1,7 @@
 import { StampHubError, convertStampHubError } from "../../error";
-import { ApprovalRequestDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { ApprovalRequestDBProvider, CatalogDBProvider } from "@stamp-lib/stamp-types/pluginInterface/database";
+import { GroupMemberShipProvider } from "@stamp-lib/stamp-types/pluginInterface/identity";
+import { createFilterVisibleApprovalRequests } from "../../events/approval-request/visibility/canViewApprovalRequest";
 import { z } from "zod";
 import { parseZodObjectAsync } from "../../utils/neverthrow";
 import { ResultAsync } from "neverthrow";
@@ -25,21 +27,43 @@ export const ListByApprovalFlowId = z.object({
 });
 export type ListByApprovalFlowId = z.infer<typeof ListByApprovalFlowId>;
 
+/**
+ * List approval requests of an approval flow for the request user.
+ * Requests that carry a visibility snapshot (restricted resources) are filtered out unless the user is the requester,
+ * an approver group member, the catalog owner or a member of the snapshot's viewer groups.
+ * paginationToken is passed through, so a page may contain fewer items than stored while a token is still present.
+ */
 export function listByApprovalFlowIdWorkflow(
   input: ListByApprovalFlowId,
   getCatalogConfigProvider: CatalogConfigProvider["get"],
-  approvalRequestDBProvider: ApprovalRequestDBProvider
+  approvalRequestDBProvider: ApprovalRequestDBProvider,
+  providers: {
+    getCatalogDBProvider: CatalogDBProvider["getById"];
+    listGroupMemberShipByUser: GroupMemberShipProvider["listByUser"];
+  }
 ): ResultAsync<{ items: Array<ApprovalRequest>; paginationToken?: string }, StampHubError> {
+  const filterVisibleApprovalRequests = createFilterVisibleApprovalRequests({
+    getCatalogDB: providers.getCatalogDBProvider,
+    listGroupMemberShipByUser: providers.listGroupMemberShipByUser,
+  });
   return parseZodObjectAsync(input, ListByApprovalFlowId)
     .andThen(createGetCatalogConfig(getCatalogConfigProvider))
     .andThen(validateApprovalFlowId)
     .andThen((parsedInput) => {
-      return approvalRequestDBProvider.listByApprovalFlowId({
-        catalogId: parsedInput.catalogId,
-        approvalFlowId: parsedInput.approvalFlowId,
-        requestDate: parsedInput.requestDate,
-        paginationToken: parsedInput.paginationToken,
-      });
+      return approvalRequestDBProvider
+        .listByApprovalFlowId({
+          catalogId: parsedInput.catalogId,
+          approvalFlowId: parsedInput.approvalFlowId,
+          requestDate: parsedInput.requestDate,
+          paginationToken: parsedInput.paginationToken,
+        })
+        .mapErr(convertStampHubError)
+        .andThen((page) =>
+          filterVisibleApprovalRequests({ requests: page.items, requestUserId: parsedInput.requestUserId, catalogId: parsedInput.catalogId }).map((items) => ({
+            items,
+            paginationToken: page.paginationToken,
+          }))
+        );
     })
     .mapErr(convertStampHubError);
 }


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### 🎉 Reason for this change

Stack **3/4** of the "resource requester groups + visibility" feature (see #102). Approval requests made for a `visibility: "restricted"` resource expose the resource (name, params, requester) to everyone through the request list and detail pages; they must only be visible to the people involved.

### 🔀 Description of changes

- `approvalRequest.get` → FORBIDDEN and `approvalRequest.listByApprovalFlowId` → filtered, unless the caller is the **requester**, a member of the request's **approver group**, the **catalog owner**, or a member of the request's **`visibility.viewerGroupIds`** (captured at submit time by #103).
- The decision is based **only on the snapshot**, so later changes to or deletion of the resource do not change who can see an existing request (no "resource row is gone" hole). Requests submitted while the resource was `all` stay visible.
- Requests without a snapshot, and the caller's own requests, short-circuit with zero identity / catalog lookups; otherwise one `listByUser` + one `catalogDB.getById` per call / page.
- `paginationToken` is passed through; the web-ui list helper (`listApprovalRequestsByCatalog`) already follows tokens recursively, so sparse pages are fine.
- `listByRequestUserId` is unchanged (it only returns the caller's own requests).
- Docs: `packages/hub/README.md` gets the two new rows in the authorization table and a "Resource access settings" section (requester groups, visibility, snapshot semantics, pagination note); `docs/user-guide/role.md` gets "Resource Requester" and "Resource Visibility".

### 🖨️ Description of how you validated changes

- New unit tests: `events/approval-request/visibility/canViewApprovalRequest.test.ts`, `workflows/approval-request/get.test.ts`; `list.test.ts` extended with `listByApprovalFlowId` cases (filtering, token passthrough, no lookups when nothing is restricted).
- `packages/hub`: 594 tests pass; `npm run lint` clean.

### 🔗 Related links

- Stack: #102 → #103 → #105 (this) → #106
- `packages/hub/README.md` "Resource access settings", `docs/user-guide/role.md`
