### PR TITLE
feat(web-ui): Request Access Setting modal for requester groups and visibility (stack 4/4)

### DIFF
--- a/apps/web-ui/.eslintrc.json
+++ b/apps/web-ui/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": ["next/core-web-vitals", "../../.eslintrc.js"],
-  "rules": {
-    "@typescript-eslint/no-unused-vars": "off"
-  }
-}

--- a/apps/web-ui/eslint.config.mjs
+++ b/apps/web-ui/eslint.config.mjs
@@ -1,0 +1,30 @@
+// ESLint flat config (ESLint 9 / Next 16). `next lint` was removed in Next 16, so run `npm run lint` (eslint .) instead.
+import js from "@eslint/js";
+import { globalIgnores } from "eslint/config";
+import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
+import tseslint from "typescript-eslint";
+
+const config = [
+  globalIgnores(["**/.next/**", "**/node_modules/**", "custom-server.js", "playwright-report/**", "test-results/**", "next-env.d.ts"]),
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  ...nextCoreWebVitals,
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": "off",
+      // React Compiler advisories introduced with eslint-config-next 16. Existing dialogs reset/fetch state in effects;
+      // report them as warnings until they are refactored so that `npm run lint` stays actionable.
+      "react-hooks/set-state-in-effect": "warn",
+      "react-hooks/preserve-manual-memoization": "warn",
+    },
+  },
+  {
+    // CommonJS config files
+    files: ["*.js", "*.cjs"],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
+];
+
+export default config;

--- a/apps/web-ui/package.json
+++ b/apps/web-ui/package.json
@@ -14,7 +14,8 @@
     "next-dev": "next dev",
     "next-build": "next build",
     "next-start": "next start",
-    "next-lint": "next lint"
+    "lint": "eslint .",
+    "next-lint": "eslint ."
   },
   "dependencies": {
     "@hono/node-server": "1.19.17",

--- a/apps/web-ui/src/app/catalog/[catalogId]/approval-flow/[approvalFlowId]/request/components/approvalRequestFilter.tsx
+++ b/apps/web-ui/src/app/catalog/[catalogId]/approval-flow/[approvalFlowId]/request/components/approvalRequestFilter.tsx
@@ -77,8 +77,8 @@ export const ApprovalRequestFilter = ({
     params.set("start", start.toISOString());
     params.set("end", end.toISOString());
 
-    selectedStatus && params.set("status", selectedStatus);
-    selectedApproverId && params.set("approverId", selectedApproverId);
+    if (selectedStatus) params.set("status", selectedStatus);
+    if (selectedApproverId) params.set("approverId", selectedApproverId);
 
     inputValuesMap.forEach((value: string, key: string) => {
       const prefix = "inputParams_";

--- a/apps/web-ui/src/app/catalog/[catalogId]/approval-flow/[approvalFlowId]/request/page.tsx
+++ b/apps/web-ui/src/app/catalog/[catalogId]/approval-flow/[approvalFlowId]/request/page.tsx
@@ -32,7 +32,9 @@ export default async function Page({
   const approvalFlow = await unwrapOr(stampHubClient.userRequest.approvalFlow.get.query({ catalogId, approvalFlowId }), undefined);
   if (!approvalFlow) return notFound();
 
+  // eslint-disable-next-line react-hooks/purity -- server component: the default date range is computed per request
   const start = typeof resolvedSearchParams["start"] === "string" ? resolvedSearchParams["start"] : new Date(Date.now() - 1000 * 60 * 60 * 24 * 14).toISOString(); // default 14 days ago
+  // eslint-disable-next-line react-hooks/purity -- server component: the default date range is computed per request
   const end = typeof resolvedSearchParams["end"] === "string" ? resolvedSearchParams["end"] : new Date(Date.now()).toISOString();
 
   const userSession = await getSessionUser();

--- a/apps/web-ui/src/app/catalog/[catalogId]/resource-type/[resourceTypeId]/page.test.ts
+++ b/apps/web-ui/src/app/catalog/[catalogId]/resource-type/[resourceTypeId]/page.test.ts
@@ -3,7 +3,7 @@ import { runTestWithMockServers } from "../../../../../../tests/mocks/testEnviro
 import { createMockStampHubRouter } from "../../../../../../tests/mocks/router/stampHubRouter";
 
 import { router, publicProcedure } from "@stamp-lib/stamp-hub";
-import { userRouter, catalogRouter, resourceTypeRouter, resourceRouter, approvalFlowRouter } from "@stamp-lib/stamp-hub";
+import { userRouter, catalogRouter, resourceTypeRouter, resourceRouter, approvalFlowRouter, groupRouter } from "@stamp-lib/stamp-hub";
 import { createMockProcedure } from "../../../../../../tests/mocks/router/mockProcedures";
 
 test.describe.configure({ mode: "serial", timeout: 1000000 });
@@ -187,6 +187,61 @@ const mockResourceRouterWithPendingUpdate = router({
     })
   ),
   cancelUpdateParamsWithApproval: publicProcedure.mutation(createMockProcedure<typeof resourceRouter.cancelUpdateParamsWithApproval>(undefined)),
+});
+
+const dummyGroup = {
+  groupId: "8f1c2a3b-4d5e-4f6a-8b9c-0d1e2f3a4b5c",
+  groupName: "Dummy Group",
+  description: "This is a dummy group for testing",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+const anotherGroup = {
+  groupId: "1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d",
+  groupName: "Another Group",
+  description: "This is another dummy group for testing",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+const mockGroupRouter = router({
+  get: publicProcedure.query(createMockProcedure<typeof groupRouter.get>(dummyGroup)),
+  list: publicProcedure.query(createMockProcedure<typeof groupRouter.list>({ items: [dummyGroup, anotherGroup] })),
+});
+
+const dummyResourceWithRequestAccess = {
+  ...dummyResource,
+  requesterGroupIds: [dummyGroup.groupId],
+  visibility: "restricted" as const,
+};
+
+const dummyResourceOnDB = {
+  id: "dummy-resource-id",
+  catalogId: "dummy-catalog-id",
+  resourceTypeId: "dummy-resource-type+",
+};
+
+const mockResourceRouterWithRequestAccess = router({
+  listOutlines: publicProcedure.query(
+    createMockProcedure<typeof resourceRouter.listOutlines>({
+      items: [dummyResourceOutline],
+    })
+  ),
+  get: publicProcedure.query(createMockProcedure<typeof resourceRouter.get>(dummyResourceWithRequestAccess)),
+  updateRequesterGroups: publicProcedure.mutation(createMockProcedure<typeof resourceRouter.updateRequesterGroups>(dummyResourceOnDB)),
+  updateVisibility: publicProcedure.mutation(createMockProcedure<typeof resourceRouter.updateVisibility>(dummyResourceOnDB)),
+});
+
+const mockResourceRouterWithoutRequestAccess = router({
+  listOutlines: publicProcedure.query(
+    createMockProcedure<typeof resourceRouter.listOutlines>({
+      items: [dummyResourceOutline],
+    })
+  ),
+  get: publicProcedure.query(createMockProcedure<typeof resourceRouter.get>(dummyResource)),
+  updateRequesterGroups: publicProcedure.mutation(createMockProcedure<typeof resourceRouter.updateRequesterGroups>(dummyResourceOnDB)),
+  updateVisibility: publicProcedure.mutation(createMockProcedure<typeof resourceRouter.updateVisibility>(dummyResourceOnDB)),
 });
 
 test.describe("Resource Type Page", () => {
@@ -579,6 +634,117 @@ test.describe("Resource Type Page", () => {
 
       // Modal should be closed regardless of redirect success
       await expect(page.getByRole("dialog")).not.toBeVisible();
+    });
+  });
+  test("should open Request Access Setting modal prefilled with current settings and submit", async ({ page, context }) => {
+    const mockRouter = createMockStampHubRouter({
+      systemRequest: router({
+        user: mockUserRouter,
+      }),
+      userRequest: router({
+        catalog: mockCatalogRouter,
+        resourceType: mockResourceTypeRouter,
+        resource: mockResourceRouterWithRequestAccess,
+        group: mockGroupRouter,
+      }),
+    });
+
+    await runTestWithMockServers(context, mockRouter, async () => {
+      await page.goto("http://localhost:3000/catalog/dummy-catalog-id/resource-type/dummy-resource-type%2B");
+      await page.waitForLoadState("load");
+      await expect(page.getByRole("link", { name: "Dummy Resource" })).toBeVisible();
+
+      const resourceRow = page.locator("tr").filter({ hasText: "Dummy Resource" });
+      await resourceRow.locator("svg").last().click();
+      await expect(page.getByText("Request Access Setting")).toBeVisible();
+      await page.getByText("Request Access Setting").click();
+
+      await expect(page.getByRole("dialog")).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Request access setting" })).toBeVisible();
+
+      // Prefilled: one requester group chip + hidden input, visibility restricted
+      await expect(page.locator('input[name="requesterGroupIds"]')).toHaveCount(1);
+      await expect(page.locator('input[name="requesterGroupIds"]')).toHaveValue(dummyGroup.groupId);
+      await expect(page.getByRole("dialog").getByText("Dummy Group")).toBeVisible();
+      await expect(page.getByRole("radio", { name: /Restricted/ })).toBeChecked();
+
+      // Add another group through the combobox
+      await page.getByRole("button", { name: /Select groups/ }).click();
+      await page.getByRole("option", { name: "Another Group" }).click();
+      await page.keyboard.press("Escape");
+      await expect(page.locator('input[name="requesterGroupIds"]')).toHaveCount(2);
+
+      // Remove the first chip
+      await page.getByRole("button", { name: "Remove Dummy Group" }).click();
+      await expect(page.locator('input[name="requesterGroupIds"]')).toHaveCount(1);
+      await expect(page.locator('input[name="requesterGroupIds"]')).toHaveValue(anotherGroup.groupId);
+
+      await page.getByRole("button", { name: "Update" }).click();
+      await page.waitForTimeout(2000);
+      await expect(page.getByRole("dialog")).not.toBeVisible();
+    });
+  });
+
+  test("should show anyone-can-request state and warn when restricting without any group", async ({ page, context }) => {
+    const mockRouter = createMockStampHubRouter({
+      systemRequest: router({
+        user: mockUserRouter,
+      }),
+      userRequest: router({
+        catalog: mockCatalogRouter,
+        resourceType: mockResourceTypeRouter,
+        resource: mockResourceRouterWithoutRequestAccess,
+        group: mockGroupRouter,
+      }),
+    });
+
+    await runTestWithMockServers(context, mockRouter, async () => {
+      await page.goto("http://localhost:3000/catalog/dummy-catalog-id/resource-type/dummy-resource-type%2B");
+      await page.waitForLoadState("load");
+      await expect(page.getByRole("link", { name: "Dummy Resource" })).toBeVisible();
+
+      const resourceRow = page.locator("tr").filter({ hasText: "Dummy Resource" });
+      await resourceRow.locator("svg").last().click();
+      await page.getByText("Request Access Setting").click();
+      await expect(page.getByRole("dialog")).toBeVisible();
+
+      await expect(page.getByText("No groups selected. Anyone can request this resource.")).toBeVisible();
+      await expect(page.locator('input[name="requesterGroupIds"]')).toHaveCount(0);
+      await expect(page.getByRole("radio", { name: /^All/ })).toBeChecked();
+
+      // dummyResource has owner/approver groups, so no warning even when restricted
+      await page.getByRole("radio", { name: /Restricted/ }).click();
+      await expect(page.getByText("No requester, approver or owner group is set.")).not.toBeVisible();
+
+      await page.getByRole("button", { name: "Update" }).click();
+      await page.waitForTimeout(2000);
+      await expect(page.getByRole("dialog")).not.toBeVisible();
+    });
+  });
+
+  test("should display Requester Groups and Visibility in the resource info dialog", async ({ page, context }) => {
+    const mockRouter = createMockStampHubRouter({
+      systemRequest: router({
+        user: mockUserRouter,
+      }),
+      userRequest: router({
+        catalog: mockCatalogRouter,
+        resourceType: mockResourceTypeRouter,
+        resource: mockResourceRouterWithRequestAccess,
+        group: mockGroupRouter,
+      }),
+    });
+
+    await runTestWithMockServers(context, mockRouter, async () => {
+      await page.goto("http://localhost:3000/catalog/dummy-catalog-id/resource-type/dummy-resource-type%2B");
+      await page.waitForLoadState("load");
+
+      await page.getByRole("link", { name: "Dummy Resource" }).click();
+      await expect(page.getByRole("dialog")).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Requester Groups" })).toBeVisible();
+      await expect(page.getByRole("dialog").getByRole("link", { name: /Dummy Group/ })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Visibility" })).toBeVisible();
+      await expect(page.getByText("Restricted (requester, approver and owner groups only)")).toBeVisible();
     });
   });
 });

--- a/apps/web-ui/src/app/user/[userId]/approval-requests/components/approvalRequestFilter.tsx
+++ b/apps/web-ui/src/app/user/[userId]/approval-requests/components/approvalRequestFilter.tsx
@@ -113,10 +113,10 @@ export const ApprovalRequestFilter = ({
     params.set("start", start.toISOString());
     params.set("end", end.toISOString());
 
-    selectedStatus && params.set("status", selectedStatus);
-    selectedApproverId && params.set("approverId", selectedApproverId);
-    selectedCatalogId && params.set("catalogId", selectedCatalogId);
-    selectedApprovalFlowId && params.set("approvalFlowId", selectedApprovalFlowId);
+    if (selectedStatus) params.set("status", selectedStatus);
+    if (selectedApproverId) params.set("approverId", selectedApproverId);
+    if (selectedCatalogId) params.set("catalogId", selectedCatalogId);
+    if (selectedApprovalFlowId) params.set("approvalFlowId", selectedApprovalFlowId);
 
     inputValuesMap.forEach((value: string, key: string) => {
       const prefix = "inputParams_";

--- a/apps/web-ui/src/app/user/[userId]/approval-requests/page.tsx
+++ b/apps/web-ui/src/app/user/[userId]/approval-requests/page.tsx
@@ -26,7 +26,9 @@ export default async function Page({
   const logger = createServerLogger();
   logger.info("params", resolvedParams);
   const user = await getUser(resolvedParams.userId);
+  // eslint-disable-next-line react-hooks/purity -- server component: the default date range is computed per request
   const start = typeof resolvedSearchParams["start"] === "string" ? resolvedSearchParams["start"] : new Date(Date.now() - 1000 * 60 * 60 * 24 * 14).toISOString(); // default 14 days ago
+  // eslint-disable-next-line react-hooks/purity -- server component: the default date range is computed per request
   const end = typeof resolvedSearchParams["end"] === "string" ? resolvedSearchParams["end"] : new Date(Date.now()).toISOString();
 
   const status = getParamAsString(resolvedSearchParams, "status");

--- a/apps/web-ui/src/client-lib/api-clients/group.test.ts
+++ b/apps/web-ui/src/client-lib/api-clients/group.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { listGroups } from "./group";
+
+const group = (groupId: string, groupName: string) => ({
+  groupId,
+  groupName,
+  description: "",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+});
+
+describe("listGroups", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns the groups of a single page", async () => {
+    const mockFetch = vi.fn();
+    global.fetch = mockFetch;
+    const response = { items: [group("g1", "Group 1"), group("g2", "Group 2")] };
+    mockFetch.mockReturnValue(Promise.resolve(new Response(JSON.stringify(response), { status: 200 })));
+
+    const result = await listGroups();
+
+    expect(result).toEqual(response.items);
+    expect(mockFetch).toHaveBeenCalledWith("/api/group/list");
+  });
+
+  it("follows nextPaginationToken", async () => {
+    const mockFetch = vi.fn();
+    global.fetch = mockFetch;
+    mockFetch.mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify({ items: [group("g1", "Group 1")], nextPaginationToken: "abc123" }), { status: 200 })));
+    mockFetch.mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify({ items: [group("g2", "Group 2")] }), { status: 200 })));
+
+    const result = await listGroups();
+
+    expect(result.map((g) => g.groupId)).toEqual(["g1", "g2"]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenNthCalledWith(2, "/api/group/list?paginationToken=abc123");
+  });
+
+  it("passes groupNamePrefix", async () => {
+    const mockFetch = vi.fn();
+    global.fetch = mockFetch;
+    mockFetch.mockReturnValue(Promise.resolve(new Response(JSON.stringify({ items: [] }), { status: 200 })));
+
+    await listGroups({ groupNamePrefix: "dev team" });
+
+    expect(mockFetch).toHaveBeenCalledWith("/api/group/list?groupNamePrefix=dev+team");
+  });
+
+  it("throws when the response is not ok", async () => {
+    const mockFetch = vi.fn();
+    global.fetch = mockFetch;
+    mockFetch.mockReturnValue(Promise.resolve(new Response("error", { status: 500, statusText: "Internal Server Error" })));
+
+    await expect(listGroups()).rejects.toThrow("Failed to fetch groups");
+  });
+});

--- a/apps/web-ui/src/client-lib/api-clients/group.ts
+++ b/apps/web-ui/src/client-lib/api-clients/group.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { StampHubRouterOutput } from "@stamp-lib/stamp-hub";
+import { Group } from "@/type";
+
+/**
+ * List groups visible to the current user via /api/group/list, following pagination to the end.
+ */
+export async function listGroups({ groupNamePrefix, paginationToken }: { groupNamePrefix?: string; paginationToken?: string } = {}): Promise<Array<Group>> {
+  const params = new URLSearchParams();
+  if (groupNamePrefix) {
+    params.set("groupNamePrefix", groupNamePrefix);
+  }
+  if (paginationToken) {
+    params.set("paginationToken", paginationToken);
+  }
+  const query = params.toString();
+  const url = query ? `/api/group/list?${query}` : "/api/group/list";
+  const result = await fetch(url);
+  if (!result.ok) throw new Error(`Failed to fetch groups: ${result.statusText}`);
+  const response = (await result.json()) as StampHubRouterOutput["userRequest"]["group"]["list"];
+  if (response.nextPaginationToken) {
+    const nextItems = await listGroups({ groupNamePrefix, paginationToken: response.nextPaginationToken });
+    return response.items.concat(nextItems);
+  }
+  return response.items;
+}

--- a/apps/web-ui/src/client-lib/api-clients/resource.ts
+++ b/apps/web-ui/src/client-lib/api-clients/resource.ts
@@ -1,7 +1,14 @@
 "use client";
 
 import { StampHubRouterOutput } from "@stamp-lib/stamp-hub";
-import { ResourceOutline } from "@/type";
+import { Resource, ResourceOutline } from "@/type";
+
+export async function getResource({ catalogId, resourceTypeId, resourceId }: { catalogId: string; resourceTypeId: string; resourceId: string }): Promise<Resource> {
+  const params = new URLSearchParams({ catalogId, resourceTypeId, resourceId });
+  const result = await fetch(`/api/resource/get?${params.toString()}`);
+  if (!result.ok) throw new Error(`Failed to fetch resource: ${result.statusText}`);
+  return (await result.json()) as StampHubRouterOutput["userRequest"]["resource"]["get"];
+}
 
 export async function listResourceOutlines({
   catalogId,

--- a/apps/web-ui/src/components/combobox/command.tsx
+++ b/apps/web-ui/src/components/combobox/command.tsx
@@ -43,6 +43,11 @@ const CommandSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => <CommandPrimitive.Separator ref={ref} className={"-mx-1 h-px p-1 bg-border"} {...props} />);
 CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
 
+const CommandEmpty = React.forwardRef<React.ElementRef<typeof CommandPrimitive.Empty>, React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>>(
+  (props, ref) => <CommandPrimitive.Empty ref={ref} className={"py-2 px-2 font-sans text-2 text-gray-9"} {...props} />
+);
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
+
 const CommandItem = React.forwardRef<React.ElementRef<typeof CommandPrimitive.Item>, React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>>(
   ({ className, ...props }, ref) => (
     <CommandPrimitive.Item
@@ -54,4 +59,4 @@ const CommandItem = React.forwardRef<React.ElementRef<typeof CommandPrimitive.It
 );
 CommandItem.displayName = CommandPrimitive.Item.displayName;
 
-export { Command, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator };
+export { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator };

--- a/apps/web-ui/src/components/group/selectGroups.tsx
+++ b/apps/web-ui/src/components/group/selectGroups.tsx
@@ -47,11 +47,9 @@ export function SelectGroups({
 
   return (
     <Flex direction="column" gap="2">
-      <label htmlFor={name}>
-        <Text as="div" size="2" weight="bold">
-          {label}
-        </Text>
-      </label>
+      <Text as="div" size="2" weight="bold">
+        {label}
+      </Text>
       {selectedGroupIds.map((groupId) => (
         <input key={groupId} type="hidden" name={name} value={groupId} />
       ))}
@@ -78,7 +76,7 @@ export function SelectGroups({
         )
       )}
       <Popover.Root open={openPopover} onOpenChange={setOpenPopover}>
-        <Popover.Trigger disabled={disabled || isLoading || groups.length === 0} id={name}>
+        <Popover.Trigger disabled={disabled || isLoading || groups.length === 0}>
           <Button type="button" color="gray" variant="surface">
             <Text weight="light" highContrast>
               {triggerText}

--- a/apps/web-ui/src/components/group/selectGroups.tsx
+++ b/apps/web-ui/src/components/group/selectGroups.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { Group } from "@/type";
+import { CaretSortIcon, CheckIcon, Cross2Icon } from "@radix-ui/react-icons";
+import { Badge, Button, Flex, IconButton, Popover, Text } from "@radix-ui/themes";
+import React from "react";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "../combobox/command";
+
+/**
+ * Searchable multi-select of groups.
+ * Renders one hidden input per selected group (name={name}) so a surrounding form can read them with formData.getAll(name).
+ * Pure UI: the caller owns the group list and the selection.
+ */
+export function SelectGroups({
+  name,
+  groups,
+  selectedGroupIds,
+  onChange,
+  label,
+  placeholder = "Select groups…",
+  emptyText,
+  disabled = false,
+}: {
+  name: string;
+  groups: Array<Group> | undefined; // undefined while loading
+  selectedGroupIds: Array<string>;
+  onChange: (groupIds: Array<string>) => void;
+  label: string;
+  placeholder?: string;
+  emptyText?: string;
+  disabled?: boolean;
+}) {
+  const [openPopover, setOpenPopover] = React.useState(false);
+  const groupNameOf = (groupId: string) => groups?.find((group) => group.groupId === groupId)?.groupName;
+
+  const toggle = (groupId: string) => {
+    if (selectedGroupIds.includes(groupId)) {
+      onChange(selectedGroupIds.filter((id) => id !== groupId));
+    } else {
+      onChange([...selectedGroupIds, groupId]);
+    }
+  };
+  const remove = (groupId: string) => onChange(selectedGroupIds.filter((id) => id !== groupId));
+
+  const isLoading = groups === undefined;
+  const triggerText = isLoading ? "Loading groups…" : placeholder;
+
+  return (
+    <Flex direction="column" gap="2">
+      <label htmlFor={name}>
+        <Text as="div" size="2" weight="bold">
+          {label}
+        </Text>
+      </label>
+      {selectedGroupIds.map((groupId) => (
+        <input key={groupId} type="hidden" name={name} value={groupId} />
+      ))}
+      {selectedGroupIds.length > 0 ? (
+        <Flex wrap="wrap" gap="1">
+          {selectedGroupIds.map((groupId) => {
+            const groupName = groupNameOf(groupId);
+            const displayName = groupName ?? `Unknown group (${groupId.slice(0, 8)}…)`;
+            return (
+              <Badge key={groupId} variant="soft" size="2" color={groupName ? undefined : "gray"}>
+                {displayName}
+                <IconButton type="button" size="1" variant="ghost" color="gray" aria-label={`Remove ${displayName}`} disabled={disabled} onClick={() => remove(groupId)}>
+                  <Cross2Icon />
+                </IconButton>
+              </Badge>
+            );
+          })}
+        </Flex>
+      ) : (
+        emptyText && (
+          <Text size="2" color="gray">
+            {emptyText}
+          </Text>
+        )
+      )}
+      <Popover.Root open={openPopover} onOpenChange={setOpenPopover}>
+        <Popover.Trigger disabled={disabled || isLoading || groups.length === 0} id={name}>
+          <Button type="button" color="gray" variant="surface">
+            <Text weight="light" highContrast>
+              {triggerText}
+            </Text>
+            <CaretSortIcon />
+          </Button>
+        </Popover.Trigger>
+        <Popover.Content size="1">
+          <Command style={{ width: "280px" }}>
+            <CommandInput placeholder="Search groups…" />
+            <CommandList>
+              <CommandEmpty>No group found.</CommandEmpty>
+              <CommandGroup>
+                {(groups ?? []).map((group) => (
+                  <CommandItem key={group.groupId} value={group.groupId} keywords={[group.groupName]} onSelect={(groupId: string) => toggle(groupId)}>
+                    <Flex align="center" px="1">
+                      <CheckIcon className={selectedGroupIds.includes(group.groupId) ? "opacity-100" : "opacity-0"} />
+                    </Flex>
+                    {group.groupName}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </Popover.Content>
+      </Popover.Root>
+      {!isLoading && groups.length === 0 && (
+        <Text size="2" color="gray">
+          No groups available.
+        </Text>
+      )}
+    </Flex>
+  );
+}

--- a/apps/web-ui/src/components/resource/dotsMenu.tsx
+++ b/apps/web-ui/src/components/resource/dotsMenu.tsx
@@ -13,6 +13,7 @@ import { updateOwnerGroup } from "@/server-actions/resource/updateOwnerGroup";
 import { deleteResource } from "@/server-actions/resource/deleteResource";
 import { NotificationSettingModal } from "./setResourceNotification";
 import { ResourceEditModal } from "./resourceEditModal";
+import { RequestAccessSettingModal } from "./requestAccessSettingModal";
 
 export function DotsMenu({ resourceType, resourceOutline }: { resourceType: ResourceType; resourceOutline: ResourceOutline }) {
   const isNotUpdatable = !resourceType.isUpdatable;
@@ -22,6 +23,7 @@ export function DotsMenu({ resourceType, resourceOutline }: { resourceType: Reso
   const [EditParamsModalOpen, setEditParamsModalOpen] = useState(false);
   const [OwnerSettingModalOpen, setOwnerSettingModalOpen] = useState(false);
   const [ApproverSettingModalOpen, setApproverSettingModalOpen] = useState(false);
+  const [RequestAccessSettingModalOpen, setRequestAccessSettingModalOpen] = useState(false);
   const [NotificationSettingModalOpen, setNotificationSettingModalOpen] = useState(false);
   const [DeleteModalOpen, setDeleteModalOpen] = useState(false);
 
@@ -29,12 +31,19 @@ export function DotsMenu({ resourceType, resourceOutline }: { resourceType: Reso
   // https://github.com/radix-ui/primitives/issues/2355
   // https://github.com/radix-ui/primitives/issues/1241#issuecomment-1888232392
   useEffect(() => {
-    if (!EditParamsModalOpen || !OwnerSettingModalOpen || !ApproverSettingModalOpen || !DeleteModalOpen) {
+    if (
+      !EditParamsModalOpen ||
+      !OwnerSettingModalOpen ||
+      !ApproverSettingModalOpen ||
+      !RequestAccessSettingModalOpen ||
+      !NotificationSettingModalOpen ||
+      !DeleteModalOpen
+    ) {
       setTimeout(() => {
         document.body.style.pointerEvents = "";
       }, 500);
     }
-  }, [EditParamsModalOpen, OwnerSettingModalOpen, ApproverSettingModalOpen, DeleteModalOpen]);
+  }, [EditParamsModalOpen, OwnerSettingModalOpen, ApproverSettingModalOpen, RequestAccessSettingModalOpen, NotificationSettingModalOpen, DeleteModalOpen]);
 
   return (
     <Flex>
@@ -67,6 +76,13 @@ export function DotsMenu({ resourceType, resourceOutline }: { resourceType: Reso
               }}
             >
               Approver Setting
+            </DropdownMenu.Item>
+            <DropdownMenu.Item
+              onClick={() => {
+                setRequestAccessSettingModalOpen(true);
+              }}
+            >
+              Request Access Setting
             </DropdownMenu.Item>
             <DropdownMenu.Item
               onClick={() => {
@@ -104,6 +120,12 @@ export function DotsMenu({ resourceType, resourceOutline }: { resourceType: Reso
           resourceOutline={resourceOutline}
           modalOpen={ApproverSettingModalOpen}
           setModalOpen={setApproverSettingModalOpen}
+        />
+        <RequestAccessSettingModal
+          resourceType={resourceType}
+          resourceOutline={resourceOutline}
+          modalOpen={RequestAccessSettingModalOpen}
+          setModalOpen={setRequestAccessSettingModalOpen}
         />
         <NotificationSettingModal resourceOutline={resourceOutline} modalOpen={NotificationSettingModalOpen} setModalOpen={setNotificationSettingModalOpen} />
         <DeleteModal resourceType={resourceType} resourceOutline={resourceOutline} modalOpen={DeleteModalOpen} setModalOpen={setDeleteModalOpen} />

--- a/apps/web-ui/src/components/resource/requestAccessSettingModal.tsx
+++ b/apps/web-ui/src/components/resource/requestAccessSettingModal.tsx
@@ -1,0 +1,161 @@
+"use client";
+import { getResource } from "@/client-lib/api-clients/resource";
+import { listGroups } from "@/client-lib/api-clients/group";
+import { SelectGroups } from "@/components/group/selectGroups";
+import { updateRequestAccess } from "@/server-actions/resource/updateRequestAccess";
+import { Group, ResourceOutline, ResourceType } from "@/type";
+import { Button, Callout, Dialog, Flex, RadioGroup, Text } from "@radix-ui/themes";
+import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
+import { useRouter } from "next/navigation";
+import { Dispatch, SetStateAction, useActionState, useEffect, useState } from "react";
+import { useFormStatus } from "react-dom";
+
+type Visibility = "all" | "restricted";
+
+export function RequestAccessSettingModal({
+  resourceType,
+  resourceOutline,
+  modalOpen,
+  setModalOpen,
+}: {
+  resourceType: ResourceType;
+  resourceOutline: ResourceOutline;
+  modalOpen: boolean;
+  setModalOpen: Dispatch<SetStateAction<boolean>>;
+}) {
+  const router = useRouter();
+  const [state, formAction] = useActionState(updateRequestAccess, undefined);
+  const [groups, setGroups] = useState<Array<Group> | undefined>(undefined);
+  const [selectedGroupIds, setSelectedGroupIds] = useState<Array<string>>([]);
+  const [visibility, setVisibility] = useState<Visibility>("all");
+  const [hasOwnerOrApprover, setHasOwnerOrApprover] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!modalOpen) {
+      setGroups(undefined);
+      setSelectedGroupIds([]);
+      setVisibility("all");
+      setHasOwnerOrApprover(false);
+      setLoadError(undefined);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    Promise.all([
+      getResource({ catalogId: resourceOutline.catalogId, resourceTypeId: resourceOutline.resourceTypeId, resourceId: resourceOutline.id }),
+      listGroups(),
+    ])
+      .then(([resource, groupList]) => {
+        if (cancelled) return;
+        setGroups(groupList);
+        setSelectedGroupIds(resource.requesterGroupIds ?? []);
+        setVisibility(resource.visibility === "restricted" ? "restricted" : "all");
+        setHasOwnerOrApprover(Boolean(resource.ownerGroupId || resource.approverGroupId));
+      })
+      .catch((e: Error) => {
+        if (cancelled) return;
+        setLoadError(e.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [modalOpen, resourceOutline]);
+
+  useEffect(() => {
+    if (state?.isSuccess === true) {
+      setModalOpen(false);
+      router.refresh();
+    }
+  }, [router, state, setModalOpen]);
+
+  const restrictedWithoutViewers = visibility === "restricted" && selectedGroupIds.length === 0 && !hasOwnerOrApprover;
+
+  return (
+    <Dialog.Root open={modalOpen} onOpenChange={setModalOpen}>
+      <Dialog.Content style={{ maxWidth: 480 }}>
+        <Dialog.Title>Request access setting</Dialog.Title>
+        <Dialog.Description size="2" mb="4">
+          Control who can request and who can see {resourceOutline.name}.
+        </Dialog.Description>
+
+        <form action={formAction}>
+          <input type="hidden" name="catalogId" value={resourceType.catalogId} />
+          <input type="hidden" name="resourceTypeId" value={resourceType.id} />
+          <input type="hidden" name="resourceId" value={resourceOutline.id} />
+          <Flex direction="column" gap="4">
+            <Flex direction="column" gap="1">
+              <SelectGroups
+                name="requesterGroupIds"
+                label="Requester groups"
+                groups={groups}
+                selectedGroupIds={selectedGroupIds}
+                onChange={setSelectedGroupIds}
+                emptyText="No groups selected. Anyone can request this resource."
+                disabled={loading}
+              />
+              <Text size="1" color="gray">
+                Only members of the selected groups can submit approval requests for this resource. Leave it empty to allow anyone.
+              </Text>
+            </Flex>
+
+            <Flex direction="column" gap="1">
+              <Text as="div" size="2" weight="bold">
+                Visibility
+              </Text>
+              <RadioGroup.Root name="visibility" value={visibility} onValueChange={(value) => setVisibility(value as Visibility)} disabled={loading}>
+                <RadioGroup.Item value="all">All — everyone can see this resource</RadioGroup.Item>
+                <RadioGroup.Item value="restricted">Restricted — only requester, approver and owner groups</RadioGroup.Item>
+              </RadioGroup.Root>
+              {restrictedWithoutViewers && (
+                <Callout.Root color="red" size="1">
+                  <Callout.Icon>
+                    <ExclamationTriangleIcon />
+                  </Callout.Icon>
+                  <Callout.Text>
+                    No requester, approver or owner group is set. Only the catalog owner and the parent resource owner will be able to see this resource.
+                  </Callout.Text>
+                </Callout.Root>
+              )}
+            </Flex>
+          </Flex>
+          {loadError && (
+            <Flex gap="3" mt="4" justify="end">
+              <Text size="2" color="red">
+                Failed to load current settings: {loadError}
+              </Text>
+            </Flex>
+          )}
+          {state?.isSuccess === false && state?.message && (
+            <Flex gap="3" mt="4" justify="end">
+              <Text size="2" color="red">
+                {state.message}
+              </Text>
+            </Flex>
+          )}
+          <Flex gap="3" mt="4" justify="end">
+            <Dialog.Close>
+              <Button type="button" variant="soft" color="gray">
+                Cancel
+              </Button>
+            </Dialog.Close>
+            <UpdateButton disabled={loading || loadError !== undefined} />
+          </Flex>
+        </form>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}
+
+function UpdateButton({ disabled }: { disabled: boolean }) {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending || disabled}>
+      {pending ? "Updating..." : "Update"}
+    </Button>
+  );
+}

--- a/apps/web-ui/src/components/resource/requestAccessSettingModal.tsx
+++ b/apps/web-ui/src/components/resource/requestAccessSettingModal.tsx
@@ -23,48 +23,70 @@ export function RequestAccessSettingModal({
   modalOpen: boolean;
   setModalOpen: Dispatch<SetStateAction<boolean>>;
 }) {
+  return (
+    <Dialog.Root open={modalOpen} onOpenChange={setModalOpen}>
+      <Dialog.Content style={{ maxWidth: 480 }}>
+        <Dialog.Title>Request access setting</Dialog.Title>
+        <Dialog.Description size="2" mb="4">
+          Control who can request and who can see {resourceOutline.name}.
+        </Dialog.Description>
+        {/* Mounted only while open so that the form state is loaded fresh each time and discarded on close. */}
+        {modalOpen && <RequestAccessSettingForm resourceType={resourceType} resourceOutline={resourceOutline} setModalOpen={setModalOpen} />}
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}
+
+type CurrentSettings = {
+  groups: Array<Group>;
+  requesterGroupIds: Array<string>;
+  visibility: Visibility;
+  hasOwnerOrApprover: boolean;
+};
+
+function RequestAccessSettingForm({
+  resourceType,
+  resourceOutline,
+  setModalOpen,
+}: {
+  resourceType: ResourceType;
+  resourceOutline: ResourceOutline;
+  setModalOpen: Dispatch<SetStateAction<boolean>>;
+}) {
   const router = useRouter();
   const [state, formAction] = useActionState(updateRequestAccess, undefined);
-  const [groups, setGroups] = useState<Array<Group> | undefined>(undefined);
+  const [current, setCurrent] = useState<CurrentSettings | undefined>(undefined);
+  const [loadError, setLoadError] = useState<string | undefined>(undefined);
   const [selectedGroupIds, setSelectedGroupIds] = useState<Array<string>>([]);
   const [visibility, setVisibility] = useState<Visibility>("all");
-  const [hasOwnerOrApprover, setHasOwnerOrApprover] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [loadError, setLoadError] = useState<string | undefined>(undefined);
 
   useEffect(() => {
-    if (!modalOpen) {
-      setGroups(undefined);
-      setSelectedGroupIds([]);
-      setVisibility("all");
-      setHasOwnerOrApprover(false);
-      setLoadError(undefined);
-      return;
-    }
     let cancelled = false;
-    setLoading(true);
     Promise.all([
       getResource({ catalogId: resourceOutline.catalogId, resourceTypeId: resourceOutline.resourceTypeId, resourceId: resourceOutline.id }),
       listGroups(),
     ])
-      .then(([resource, groupList]) => {
+      .then(([resource, groups]) => {
         if (cancelled) return;
-        setGroups(groupList);
-        setSelectedGroupIds(resource.requesterGroupIds ?? []);
-        setVisibility(resource.visibility === "restricted" ? "restricted" : "all");
-        setHasOwnerOrApprover(Boolean(resource.ownerGroupId || resource.approverGroupId));
+        const requesterGroupIds = resource.requesterGroupIds ?? [];
+        const currentVisibility: Visibility = resource.visibility === "restricted" ? "restricted" : "all";
+        setCurrent({
+          groups,
+          requesterGroupIds,
+          visibility: currentVisibility,
+          hasOwnerOrApprover: Boolean(resource.ownerGroupId || resource.approverGroupId),
+        });
+        setSelectedGroupIds(requesterGroupIds);
+        setVisibility(currentVisibility);
       })
       .catch((e: Error) => {
         if (cancelled) return;
         setLoadError(e.message);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
       });
     return () => {
       cancelled = true;
     };
-  }, [modalOpen, resourceOutline]);
+  }, [resourceOutline]);
 
   useEffect(() => {
     if (state?.isSuccess === true) {
@@ -73,81 +95,73 @@ export function RequestAccessSettingModal({
     }
   }, [router, state, setModalOpen]);
 
-  const restrictedWithoutViewers = visibility === "restricted" && selectedGroupIds.length === 0 && !hasOwnerOrApprover;
+  const loading = current === undefined && loadError === undefined;
+  const restrictedWithoutViewers = visibility === "restricted" && selectedGroupIds.length === 0 && current !== undefined && !current.hasOwnerOrApprover;
 
   return (
-    <Dialog.Root open={modalOpen} onOpenChange={setModalOpen}>
-      <Dialog.Content style={{ maxWidth: 480 }}>
-        <Dialog.Title>Request access setting</Dialog.Title>
-        <Dialog.Description size="2" mb="4">
-          Control who can request and who can see {resourceOutline.name}.
-        </Dialog.Description>
+    <form action={formAction}>
+      <input type="hidden" name="catalogId" value={resourceType.catalogId} />
+      <input type="hidden" name="resourceTypeId" value={resourceType.id} />
+      <input type="hidden" name="resourceId" value={resourceOutline.id} />
+      <Flex direction="column" gap="4">
+        <Flex direction="column" gap="1">
+          <SelectGroups
+            name="requesterGroupIds"
+            label="Requester groups"
+            groups={current?.groups}
+            selectedGroupIds={selectedGroupIds}
+            onChange={setSelectedGroupIds}
+            emptyText="No groups selected. Anyone can request this resource."
+            disabled={loading}
+          />
+          <Text size="1" color="gray">
+            Only members of the selected groups can submit approval requests for this resource. Leave it empty to allow anyone.
+          </Text>
+        </Flex>
 
-        <form action={formAction}>
-          <input type="hidden" name="catalogId" value={resourceType.catalogId} />
-          <input type="hidden" name="resourceTypeId" value={resourceType.id} />
-          <input type="hidden" name="resourceId" value={resourceOutline.id} />
-          <Flex direction="column" gap="4">
-            <Flex direction="column" gap="1">
-              <SelectGroups
-                name="requesterGroupIds"
-                label="Requester groups"
-                groups={groups}
-                selectedGroupIds={selectedGroupIds}
-                onChange={setSelectedGroupIds}
-                emptyText="No groups selected. Anyone can request this resource."
-                disabled={loading}
-              />
-              <Text size="1" color="gray">
-                Only members of the selected groups can submit approval requests for this resource. Leave it empty to allow anyone.
-              </Text>
-            </Flex>
-
-            <Flex direction="column" gap="1">
-              <Text as="div" size="2" weight="bold">
-                Visibility
-              </Text>
-              <RadioGroup.Root name="visibility" value={visibility} onValueChange={(value) => setVisibility(value as Visibility)} disabled={loading}>
-                <RadioGroup.Item value="all">All — everyone can see this resource</RadioGroup.Item>
-                <RadioGroup.Item value="restricted">Restricted — only requester, approver and owner groups</RadioGroup.Item>
-              </RadioGroup.Root>
-              {restrictedWithoutViewers && (
-                <Callout.Root color="red" size="1">
-                  <Callout.Icon>
-                    <ExclamationTriangleIcon />
-                  </Callout.Icon>
-                  <Callout.Text>
-                    No requester, approver or owner group is set. Only the catalog owner and the parent resource owner will be able to see this resource.
-                  </Callout.Text>
-                </Callout.Root>
-              )}
-            </Flex>
-          </Flex>
-          {loadError && (
-            <Flex gap="3" mt="4" justify="end">
-              <Text size="2" color="red">
-                Failed to load current settings: {loadError}
-              </Text>
-            </Flex>
+        <Flex direction="column" gap="1">
+          <Text as="div" size="2" weight="bold">
+            Visibility
+          </Text>
+          <RadioGroup.Root name="visibility" value={visibility} onValueChange={(value) => setVisibility(value as Visibility)} disabled={loading}>
+            <RadioGroup.Item value="all">All — everyone can see this resource</RadioGroup.Item>
+            <RadioGroup.Item value="restricted">Restricted — only requester, approver and owner groups</RadioGroup.Item>
+          </RadioGroup.Root>
+          {restrictedWithoutViewers && (
+            <Callout.Root color="red" size="1">
+              <Callout.Icon>
+                <ExclamationTriangleIcon />
+              </Callout.Icon>
+              <Callout.Text>
+                No requester, approver or owner group is set. Only the catalog owner and the parent resource owner will be able to see this resource.
+              </Callout.Text>
+            </Callout.Root>
           )}
-          {state?.isSuccess === false && state?.message && (
-            <Flex gap="3" mt="4" justify="end">
-              <Text size="2" color="red">
-                {state.message}
-              </Text>
-            </Flex>
-          )}
-          <Flex gap="3" mt="4" justify="end">
-            <Dialog.Close>
-              <Button type="button" variant="soft" color="gray">
-                Cancel
-              </Button>
-            </Dialog.Close>
-            <UpdateButton disabled={loading || loadError !== undefined} />
-          </Flex>
-        </form>
-      </Dialog.Content>
-    </Dialog.Root>
+        </Flex>
+      </Flex>
+      {loadError && (
+        <Flex gap="3" mt="4" justify="end">
+          <Text size="2" color="red">
+            Failed to load current settings: {loadError}
+          </Text>
+        </Flex>
+      )}
+      {state?.isSuccess === false && state?.message && (
+        <Flex gap="3" mt="4" justify="end">
+          <Text size="2" color="red">
+            {state.message}
+          </Text>
+        </Flex>
+      )}
+      <Flex gap="3" mt="4" justify="end">
+        <Dialog.Close>
+          <Button type="button" variant="soft" color="gray">
+            Cancel
+          </Button>
+        </Dialog.Close>
+        <UpdateButton disabled={loading || loadError !== undefined} />
+      </Flex>
+    </form>
   );
 }
 

--- a/apps/web-ui/src/components/resource/resourceInfoDialog.tsx
+++ b/apps/web-ui/src/components/resource/resourceInfoDialog.tsx
@@ -104,6 +104,24 @@ function Overview({ resourceType, resourceOutline }: { resourceType: ResourceTyp
       )}
 
       <Flex direction="column" gap="1">
+        <Heading size="3">Requester Groups</Heading>
+        <Flex p="1" direction="column" gap="1">
+          {resource.requesterGroupIds && resource.requesterGroupIds.length > 0 ? (
+            resource.requesterGroupIds.map((groupId) => <GroupLink key={groupId} groupId={groupId} />)
+          ) : (
+            <Text size="2">No setting (anyone can request)</Text>
+          )}
+        </Flex>
+      </Flex>
+
+      <Flex direction="column" gap="1">
+        <Heading size="3">Visibility</Heading>
+        <Flex p="1">
+          <Text size="2">{resource.visibility === "restricted" ? "Restricted (requester, approver and owner groups only)" : "All"}</Text>
+        </Flex>
+      </Flex>
+
+      <Flex direction="column" gap="1">
         <Heading size="3">Audit Notification</Heading>
         {resource.auditNotifications ? (
           resource.auditNotifications?.map((notification) => (

--- a/apps/web-ui/src/server-actions/resource/updateRequestAccess.ts
+++ b/apps/web-ui/src/server-actions/resource/updateRequestAccess.ts
@@ -1,0 +1,60 @@
+"use server";
+import { stampHubClient } from "@/utils/stampHubClient";
+import { getSessionUser } from "@/utils/sessionUser";
+import { createServerLogger } from "@/logger";
+
+export type UpdateRequestAccessState = {
+  errors?: Record<string, string[]>;
+  message: string | null;
+  isSuccess: boolean | null;
+};
+
+/**
+ * Update a resource's requester groups and visibility from the "Request Access Setting" modal.
+ * requesterGroupIds: every hidden input named "requesterGroupIds" (none = anyone can request).
+ * visibility: "all" | "restricted".
+ */
+export async function updateRequestAccess(prevState: UpdateRequestAccessState | undefined, formData: FormData): Promise<UpdateRequestAccessState> {
+  const logger = createServerLogger();
+  const sessionUser = await getSessionUser();
+  logger.info("updateRequestAccess:formData", formData);
+  const catalogId = formData.get("catalogId")?.toString();
+  const resourceTypeId = formData.get("resourceTypeId")?.toString();
+  const resourceId = formData.get("resourceId")?.toString();
+  const visibility = formData.get("visibility")?.toString();
+  if (!catalogId || !resourceTypeId || !resourceId || (visibility !== "all" && visibility !== "restricted")) {
+    return { message: "Lack of FormData params", isSuccess: false };
+  }
+  const requesterGroupIds = Array.from(
+    new Set(
+      formData
+        .getAll("requesterGroupIds")
+        .map((value) => value.toString())
+        .filter((value) => value.length > 0)
+    )
+  );
+
+  try {
+    await stampHubClient.userRequest.resource.updateRequesterGroups.mutate({
+      requestUserId: sessionUser.stampUserId,
+      catalogId,
+      resourceTypeId,
+      resourceId,
+      requesterGroupIds,
+    });
+  } catch (e) {
+    return { message: `Failed to update requester groups: ${(e as Error).message}`, isSuccess: false };
+  }
+  try {
+    await stampHubClient.userRequest.resource.updateVisibility.mutate({
+      requestUserId: sessionUser.stampUserId,
+      catalogId,
+      resourceTypeId,
+      resourceId,
+      visibility,
+    });
+  } catch (e) {
+    return { message: `Requester groups were updated, but failed to update visibility: ${(e as Error).message}`, isSuccess: false };
+  }
+  return { isSuccess: true, message: "success" };
+}


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### 🎉 Reason for this change

Stack **4/4** of the "resource requester groups + visibility" feature (see #102). Owners need a UI to set the requester groups and visibility introduced in #102–#105, and to see the current values.

### 🔀 Description of changes

- Resource kebab menu gets **"Request Access Setting"** (enabled for every resource type). One modal covers both settings:
  - **Requester groups** — searchable multi-select (`SelectGroups`, cmdk) fed by `/api/group/list`; selected groups render as removable chips and as hidden `requesterGroupIds` inputs. Empty = anyone can request. Unknown ids (deleted groups) show as gray chips so they can be removed.
  - **Visibility** — `All` / `Restricted` radio; a red callout warns when restricting a resource that has no requester, approver or owner group (only the catalog owner / parent owner would still see it).
  - Prefilled from `resource.get`; the form is mounted only while the dialog is open (fresh load each time, no reset-in-effect); Update is disabled while loading or if loading failed, so an empty form is never submitted by accident.
- New server action `updateRequestAccess` → `resource.updateRequesterGroups` then `resource.updateVisibility` (the error message says which one failed).
- Resource info dialog shows **Requester Groups** (links) and **Visibility**.
- Helpers: `client-lib/api-clients/group.ts` (`listGroups`, paginated), `getResource` in `api-clients/resource.ts`, `CommandEmpty` in the combobox. The DotsMenu pointer-events workaround now also covers the notification modal (pre-existing omission).
- **ESLint** (separate commit): `next lint` no longer exists in Next 16 and the legacy `.eslintrc.json` did not load under ESLint 9, so web-ui had no working lint. Added `eslint.config.mjs` (eslint:recommended + typescript-eslint + `eslint-config-next/core-web-vitals`), pointed `npm run lint` / `next-lint` at `eslint .`, and fixed the findings (`x && f()` expressions, `react-hooks/purity` annotations on server-component date defaults). The React Compiler advisories `react-hooks/set-state-in-effect` / `preserve-manual-memoization` are warnings for now (existing dialogs).

Note: `package.json` still pins `@stamp-lib/*@0.10.0`; this PR was verified against the locally built packages and needs the dependency bump after the packages are published.

### 🖨️ Description of how you validated changes

- `npx tsc --noEmit -p .` clean against the local `@stamp-lib/*` builds.
- `npm run lint`: 0 errors (9 warnings, all pre-existing React Compiler advisories).
- `npm test` (vitest): 54 pass, incl. new `client-lib/api-clients/group.test.ts`.
- Playwright `src/app/catalog/[catalogId]/resource-type/[resourceTypeId]/page.test.ts` (chromium, mock hub): **12/12 pass** — 9 existing + 3 new (prefilled modal → add/remove chip → submit; anyone-can-request state + restricted toggle; info dialog). Run locally by overlaying the built local packages (`package.json` + `dist`) into `node_modules/@stamp-lib/*`, because `npm link` symlinks sit outside `turbopack.root` and cannot be resolved by `next dev`.

### 🔗 Related links

- Stack: #102 → #103 → #105 → #106 (this)
- GitHub stacked PRs: https://docs.github.com/en/pull-requests/get-started/about-stacked-prs
